### PR TITLE
For OpenFin tray icon context menu polyfill, use monitor rect to determine whether to show menu down or up

### DIFF
--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -258,6 +258,19 @@ export class OpenFinContainer extends WebContainerBase {
         });
     }
 
+    protected getMenuHtml() {
+        return OpenFinContainer.menuHtml;
+    }
+
+    protected getMenuItemHtml(item: MenuItem) {
+        const imgHtml: string = (item.icon)
+            ? `<span><img align="absmiddle" class="context-menu-image" src="${this.ensureAbsoluteUrl(item.icon)}" /></span>`
+            : "<span>&nbsp;</span>";
+
+        return `<li class="context-menu-item" onclick="fin.desktop.InterApplicationBus.send('${(<any>this.desktop.Application.getCurrent()).uuid}`
+            + `', null, 'TrayIcon_ContextMenuClick_${this.uuid}', { id: '${item.id}' });this.close()\">${imgHtml}${item.label}</li>`;
+    }
+
     private showMenu(x: number, y: number, monitorInfo: fin.MonitorInfo, menuItems: MenuItem[]) {
         this.menuItemRef = menuItems;
 
@@ -278,7 +291,7 @@ export class OpenFinContainer extends WebContainerBase {
             , () => {
                 const win: Window = contextMenu.getNativeWindow();
                 win.document.open("text/html", "replace");
-                win.document.write(OpenFinContainer.menuHtml);
+                win.document.write(this.getMenuHtml());
                 win.document.close();
 
                 let menuItemHtml: string = "";
@@ -287,12 +300,7 @@ export class OpenFinContainer extends WebContainerBase {
                         item.id = Guid.newGuid();
                     }
 
-                    const imgHtml: string = (item.icon)
-                        ? `<span><img align="absmiddle" class="context-menu-image" src="${this.ensureAbsoluteUrl(item.icon)}" /></span>`
-                        : "<span>&nbsp;</span>";
-
-                    menuItemHtml += `<li class="context-menu-item" onclick="fin.desktop.InterApplicationBus.send('${(<any>this.desktop.Application.getCurrent()).uuid}`
-                        + `', null, 'TrayIcon_ContextMenuClick_${this.uuid}', { id: '${item.id}' });this.close()\">${imgHtml}${item.label}</li>`;
+                    menuItemHtml += this.getMenuItemHtml(item);
                 }
 
                 const contextMenuElement: HTMLElement = win.document.getElementById("contextMenu");

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -2,17 +2,20 @@ import { OpenFinContainer, OpenFinContainerWindow, OpenFinMessageBus } from "../
 import { MessageBusSubscription } from "../../../src/ipc";
 
 class MockDesktop {
+    public static application: any = {
+        uuid: "uuid",
+        getChildWindows(callback) {
+            callback([MockWindow.singleton]);
+        },
+        setTrayIcon() { }
+    }
+
     Window(): MockWindow { return new MockWindow(); }
     Notification(): any { return {}; }
     InterApplicationBus(): any { return new MockInterApplicationBus(); }
     Application: any = {
         getCurrent() {
-            return {
-                uuid: "uuid",
-                getChildWindows(callback) {
-                    callback([MockWindow.singleton]);
-                }
-            }
+            return MockDesktop.application;
         }
     }
 }
@@ -252,6 +255,13 @@ describe("OpenFinContainer", () => {
         spyOn(desktop, "Notification").and.stub();
         container.showNotification({ title: "title", message: "Test message", url: "notification.html" });
         expect(desktop.Notification).toHaveBeenCalledWith({ url: "notification.html", message: { message: "Test message" } });
+    });
+
+
+    it("addTrayIcon invokes underlying setTrayIcon", () => {
+        spyOn(MockDesktop.application, "setTrayIcon").and.stub();
+        container.addTrayIcon({ icon: 'icon', text: 'Text' }, () => { });
+        expect(MockDesktop.application.setTrayIcon).toHaveBeenCalledWith("icon", jasmine.any(Function), jasmine.any(Function), jasmine.any(Function));
     });
 });
 

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -1,5 +1,6 @@
 import { OpenFinContainer, OpenFinContainerWindow, OpenFinMessageBus } from "../../../src/OpenFin/openfin";
 import { MessageBusSubscription } from "../../../src/ipc";
+import { MenuItem } from "../../../src/menu";
 
 class MockDesktop {
     public static application: any = {
@@ -257,6 +258,21 @@ describe("OpenFinContainer", () => {
         expect(desktop.Notification).toHaveBeenCalledWith({ url: "notification.html", message: { message: "Test message" } });
     });
 
+    it ("getMenuHtml is non null and equal to static default", ()=> {
+        expect((<any>container).getMenuHtml()).toEqual(OpenFinContainer.menuHtml);
+    });
+
+    it ("getMenuItemHtml with icon has embedded icon in span", () => {
+        const menuItem: MenuItem = { id: "ID", label: "Label",  icon: "Icon" };
+        const menuItemHtml: string = (<any>container).getMenuItemHtml(menuItem);
+        expect(menuItemHtml).toEqual(`<li class="context-menu-item" onclick="fin.desktop.InterApplicationBus.send('uuid', null, 'TrayIcon_ContextMenuClick_${container.uuid}', { id: '${menuItem.id}' });this.close()"><span><img align="absmiddle" class="context-menu-image" src="${menuItem.icon}" /></span>Label</li>`);
+    });
+
+    it ("getMenuItemHtml with no icon has nbsp; in span", () => {
+        const menuItem: MenuItem = { id: "ID", label: "Label" };
+        const menuItemHtml: string = (<any>container).getMenuItemHtml(menuItem);
+        expect(menuItemHtml).toEqual(`<li class="context-menu-item" onclick="fin.desktop.InterApplicationBus.send('uuid', null, 'TrayIcon_ContextMenuClick_${container.uuid}', { id: '${menuItem.id}' });this.close()"><span>&nbsp;</span>Label</li>`);
+    });
 
     it("addTrayIcon invokes underlying setTrayIcon", () => {
         spyOn(MockDesktop.application, "setTrayIcon").and.stub();


### PR DESCRIPTION
- If menu will show off monitor, show left or up where appropriate
- Replace simple string concat with template literals
- Change menuHtml to public.  While this is still a stop gap until menu is supported natively by OpenFin, this at least allows some customization by devs.
- Remove unused styles from menu html
- Remove some whitespace from multiline template literal of html to reduce non minified file size

Windows showing icon:
![image](https://user-images.githubusercontent.com/28159742/26975832-73964086-4cef-11e7-9874-dc0ac7dcb2ac.png)

Windows hidden icon : 
![image](https://user-images.githubusercontent.com/28159742/26975860-9324ef60-4cef-11e7-9065-42612b39376a.png)

OS X:
![image](https://user-images.githubusercontent.com/28159742/26975903-ccb1002a-4cef-11e7-98f9-b1c9b854b7b6.png)

Fixes #2