### PR TITLE
Change default OpenFin window name from url to new Guid

### DIFF
--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -53,8 +53,7 @@ openWindowButton.onclick = function () {
 			minWidth: 200, minHeight: 100, maxWidth: 800, maxHeight: 600,
 			taskbar: true, icon: "assets/img/application.png",
 			minimizable: true, maximizable: true,
-			alwaysOnTop: false, center: false,
-			name: "child"
+			alwaysOnTop: false, center: false
 		});
 };
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -245,7 +245,7 @@ export class OpenFinContainer extends WebContainerBase {
 
         // OpenFin requires a name for the window to show
         if (!("name" in newOptions)) {
-            newOptions.name = url;
+            newOptions.name = Guid.newGuid();
         }
 
         return this.wrapWindow(new this.desktop.Window(newOptions));

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -192,7 +192,7 @@ describe("OpenFinContainer", () => {
         it("defaults", () => {
             let win: OpenFinContainerWindow = container.showWindow("url");
             expect(win).toBeDefined();
-            expect(desktop.Window).toHaveBeenCalledWith({ autoShow: true, url: "url", name: "url" });
+            expect(desktop.Window).toHaveBeenCalledWith({ autoShow: true, url: "url", name: jasmine.stringMatching(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/) });
         });
 
         it("showWindow defaults", () => {
@@ -206,7 +206,8 @@ describe("OpenFinContainer", () => {
                     width: "width",
                     taskbar: "taskbar",
                     center: "center",
-                    icon: "icon"
+                    icon: "icon",
+                    name: "name"
                 });
 
             expect(win).toBeDefined();
@@ -222,7 +223,7 @@ describe("OpenFinContainer", () => {
                     autoShow: true,
                     saveWindowState: false,
                     url: "url",
-                    name: "url"
+                    name: "name"
                 }
             );
         });


### PR DESCRIPTION
Since OpenFin requires a name for a window, OpenFinContainer.showWindow was defaulting the name to the url when none was provided.  This is very restricting and a large assumption for window reuse.  This changes that default when no name is provided to a unique Guid which will enable a new window for each showWindow invoked.