### PR TITLE
Change codecov PR commenting back to default

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,4 +10,3 @@ coverage:
 
 comment:
   layout: "diff, flags, files"
-  behavior: new  


### PR DESCRIPTION
The 'new' style was too noisy as it was posting on every comment and not just commit.