### PR TITLE
Refactor showWindow to createWindow

### DIFF
--- a/examples/electron/README.md
+++ b/examples/electron/README.md
@@ -27,7 +27,7 @@ let mainWindow;
 
 function createWindow() {
     let container = desktopJS.resolveContainer();
-    mainWindow = container.showWindow('http://localhost:8000');
+    mainWindow = container.createWindow('http://localhost:8000');
 }
 
 app.on("ready", createWindow);
@@ -65,7 +65,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 });
 
 btnOpenWindow.onclick = function () {
-	childWindow = container.showWindow("child.html",
+	childWindow = container.createWindow("child.html",
 		{
 			resizable: true,
 			x: 10, y: 10,

--- a/examples/electron/electron.js
+++ b/examples/electron/electron.js
@@ -7,7 +7,7 @@ let mainWindow;
 function createWindow() {
     let container = desktopJS.resolveContainer();
 
-    mainWindow = container.showWindow('http://localhost:8000');
+    mainWindow = container.createWindow('http://localhost:8000');
 
     container.addTrayIcon({ icon: __dirname + '\\..\\web\\favicon.ico', text: 'ContainerPOC' }, () => {
         mainWindow.isShowing().then((showing) => {

--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -45,7 +45,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 });
 
 openWindowButton.onclick = function () {
-	childWindow = container.showWindow("http://localhost:8000",
+	childWindow = container.createWindow("http://localhost:8000",
 		{
 			resizable: true,
 			x: 10, y: 10,

--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -154,7 +154,7 @@ export class DefaultContainer extends WebContainerBase {
         return new DefaultContainerWindow(containerWindow);
     }
 
-    public showWindow(url: string, options?: any): ContainerWindow {
+    public createWindow(url: string, options?: any): ContainerWindow {
         let features: string;
         let target = "_blank";
 

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -191,7 +191,7 @@ export class ElectronContainer extends ContainerBase {
         return new ElectronContainerWindow(containerWindow);
     }
 
-    public showWindow(url: string, options?: any): ContainerWindow {
+    public createWindow(url: string, options?: any): ContainerWindow {
         const newOptions = this.getWindowOptions(options);
         const electronWindow: any = new this.browserWindow(newOptions);
         const windowName = newOptions.name || url;

--- a/src/Minuet/minuet.ts
+++ b/src/Minuet/minuet.ts
@@ -33,7 +33,7 @@ export class MinuetContainer extends DefaultContainer { // tslint:disable-line
         return new DefaultContainerWindow(containerWindow);
     }
 
-    public showWindow(url: string, options?: any): ContainerWindow {
+    public createWindow(url: string, options?: any): ContainerWindow {
         const newOptions = this.getWindowOptions(options);
         return this.wrapWindow(this.app.window.create(url, newOptions));
     }

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -142,7 +142,8 @@ export class OpenFinContainer extends WebContainerBase {
         height: { target: "defaultHeight" },
         width: { target: "defaultWidth" },
         taskbar: { target: "showTaskbarIcon" },
-        center: { target: "defaultCentered" }
+        center: { target: "defaultCentered" },
+        show: { target: "autoShow" }
     };
 
     public windowOptionsMap: PropertyMap = OpenFinContainer.windowOptionsMap;
@@ -245,9 +246,9 @@ export class OpenFinContainer extends WebContainerBase {
         return new OpenFinContainerWindow(containerWindow);
     }
 
-    public showWindow(url: string, options?: any): ContainerWindow {
+    public createWindow(url: string, options?: any): ContainerWindow {
         const newOptions = this.getWindowOptions(options);
-        newOptions.url = url; // showWindow param will always take precedence over any passed on options
+        newOptions.url = url; // createWindow param will always take precedence over any passed on options
 
         // OpenFin requires a name for the window to show
         if (!("name" in newOptions)) {

--- a/src/container.ts
+++ b/src/container.ts
@@ -54,7 +54,7 @@ export abstract class ContainerBase implements Container {
 
     abstract getMainWindow(): ContainerWindow;
 
-    abstract showWindow(url: string, options?: any): ContainerWindow;
+    abstract createWindow(url: string, options?: any): ContainerWindow;
 
     showNotification(options: NotificationOptions) {
         throw new TypeError("Notifications not supported by this container");
@@ -96,7 +96,7 @@ export abstract class ContainerBase implements Container {
                     for (const window of layout.windows) {
                         const options: any = Object.assign({}, window.bounds);
                         options.name = window.name;
-                        this.showWindow(window.url, options);
+                        this.createWindow(window.url, options);
                     }
                 }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -39,7 +39,7 @@ export interface ContainerWindowManager {
      * @param {any} options (Optional)
      * @returns {ContainerWindow} A new native container window wrapped within a generic ContainerWindow.
      */
-    showWindow(url: string, options?: any): ContainerWindow;
+    createWindow(url: string, options?: any): ContainerWindow;
 
     /**
      * Loads a window layout from persistence

--- a/tests/unit/Default/default.spec.ts
+++ b/tests/unit/Default/default.spec.ts
@@ -76,7 +76,7 @@ describe("DefaultContainer", () => {
         expect(container.hostType).toEqual("Default");
     });
 
-    describe("showWindow", () => {
+    describe("createWindow", () => {
         let container: DefaultContainer;
 
         beforeEach(() => {
@@ -86,19 +86,19 @@ describe("DefaultContainer", () => {
 
         it("Returns a DefaultContainerWindow and invokes underlying window.open", () => {
             spyOn(window, "open").and.callThrough();
-            let newWin: DefaultContainerWindow = container.showWindow("url");
+            let newWin: DefaultContainerWindow = container.createWindow("url");
             expect(window.open).toHaveBeenCalledWith("url", "_blank", undefined);
         });
 
         it("Options target property maps to open target parameter", () => {
             spyOn(window, "open").and.callThrough();
-            let newWin: DefaultContainerWindow = container.showWindow("url", { target: "MockTarget" });
+            let newWin: DefaultContainerWindow = container.createWindow("url", { target: "MockTarget" });
             expect(window.open).toHaveBeenCalledWith("url", "MockTarget", "target=MockTarget,");
         });
 
         it("Options parameters are converted to features", () => {
             spyOn(window, "open").and.callThrough();
-            let newWin: DefaultContainerWindow = container.showWindow("url",
+            let newWin: DefaultContainerWindow = container.createWindow("url",
                 {
                     x: "x0",
                     y: "y0"
@@ -107,14 +107,14 @@ describe("DefaultContainer", () => {
         });
 
         it("Window is addded to windows", () => {
-            let newWin: any = container.showWindow("url").containerWindow;
+            let newWin: any = container.createWindow("url").containerWindow;
             expect(newWin[DefaultContainer.windowUuidPropertyKey]).toBeDefined();
             expect(newWin[DefaultContainer.windowsPropertyKey]).toBeDefined();
             expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeDefined();
         });
 
         it("Window is removed from windows on close", () => {
-            let newWin: any = container.showWindow("url").containerWindow;
+            let newWin: any = container.createWindow("url").containerWindow;
             expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeDefined();
             newWin.listener("unload", {});
             expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeUndefined();

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -176,9 +176,9 @@ describe("ElectronContainer", () => {
         expect(win.containerWindow).toEqual(innerWin);
     });
 
-    it("showWindow", () => {
+    it("createWindow", () => {
         spyOn<any>(container, "browserWindow").and.callThrough();
-        container.showWindow("url", { x: "x", taskbar: false });
+        container.createWindow("url", { x: "x", taskbar: false });
         expect((<any>container).browserWindow).toHaveBeenCalledWith({ x: "x", skipTaskbar: true });
     });
 

--- a/tests/unit/Minuet/minuet.spec.ts
+++ b/tests/unit/Minuet/minuet.spec.ts
@@ -25,9 +25,9 @@ describe("MinuetContainer", () => {
         expect(container.hostType).toEqual("Minuet/Paragon");
     });
 
-    it("showWindow", () => {
+    it("createWindow", () => {
         spyOn<any>(mockWindow, "create").and.callThrough();
-        container.showWindow("url");
+        container.createWindow("url");
         expect(mockWindow.create).toHaveBeenCalledWith("url", {});
     });
 });

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -191,21 +191,21 @@ describe("OpenFinContainer", () => {
         expect(container.hostType).toEqual("OpenFin");
     });
 
-    describe("showWindow", () => {
+    describe("createWindow", () => {
         beforeEach(() => {
             spyOn(desktop, "Window").and.stub();
         });
 
         it("defaults", () => {
-            let win: OpenFinContainerWindow = container.showWindow("url");
+            let win: OpenFinContainerWindow = container.createWindow("url");
             expect(win).toBeDefined();
             expect(desktop.Window).toHaveBeenCalledWith({ autoShow: true, url: "url", name: jasmine.stringMatching(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/) });
         });
 
-        it("showWindow defaults", () => {
+        it("createWindow defaults", () => {
             spyOn<any>(container, "ensureAbsoluteUrl").and.returnValue("absoluteIcon");
 
-            let win: OpenFinContainerWindow = container.showWindow("url",
+            let win: OpenFinContainerWindow = container.createWindow("url",
                 {
                     x: "x",
                     y: "y",

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -10,7 +10,7 @@ class TestContainer extends ContainerBase {
         return undefined;
     }
 
-    showWindow(url: string, options?: any): ContainerWindow {
+    createWindow(url: string, options?: any): ContainerWindow {
         return undefined;
     }
 
@@ -72,10 +72,10 @@ describe("container", () => {
 
         describe("window management", () => {
             it("loadLayout", (done) => {
-                spyOn(container, "showWindow").and.callThrough();
+                spyOn(container, "createWindow").and.callThrough();
                 container.loadLayout("Test").then(layout => {
                     expect(layout).toBeDefined();
-                    expect(container.showWindow).toHaveBeenCalledWith("url", { name: "name" });
+                    expect(container.createWindow).toHaveBeenCalledWith("url", { name: "name" });
                     done();
                 });
             });


### PR DESCRIPTION
While testing auto show it became apparent that showWindow is misleading.  Renaming showWindow to createWindow and standardizing on the option "show" for auto show across OpenFin and Electron.