### PR TITLE
Upon end of gulp typedoc, force sync file creation of an empty .nojekyll file in docs directory

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -166,7 +166,10 @@ gulp.task("docs", function () {
             out: "docs/",
             hideGenerator: true,
             ignoreCompilerErrors: true
-        }));
+        }))
+        .on('end', function () {
+            require('fs').writeFileSync('docs/.nojekyll', '');
+        });
 });
 
 /** Take js coverage json and remap to typescript.  Output html and text */


### PR DESCRIPTION
Fixes #32