### PR TITLE
Implement W3C Web Notification API

### DIFF
--- a/examples/electron/README.md
+++ b/examples/electron/README.md
@@ -82,17 +82,17 @@ In order to show notifications while hosted in Electron, it is necessary for you
 developer to provide a polyfill of showNotification.  This allows you the flexibility
 to use the node module of your choice for displaying notifications. 
 
-Here is an example polyfill using node-notifier.
+Here is an example polyfill using electron-notify.
 
 ```
-desktopJS.Electron.ElectronContainer.prototype.showNotification = function(options) {
+desktopJS.Electron.ElectronContainer.prototype.showNotification = function(title, options) {
 	notifier = (this.isRemote)
-         ? this.electron.require("node-notifier")
-         : require("node-notifier");
+         ? this.electron.require("electron-notify")
+         : require("electron-notify");
 
 	notifier.notify({
-		title: options.title,
-		message: options.message
+		title: title,
+		text: options.body
 	});
 };
 ```

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -4,6 +4,6 @@
   "description": "desktopJS Demo",
   "main": "electron.js",
   "dependencies": {
-    "node-notifier": "^5.1.2"
+    "electron-notify": "^0.1.0"
   }
 }

--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -30,12 +30,13 @@ desktopJS.Default.DefaultContainerWindow.prototype.getSnapshot = function () {
 };
 */
 
-desktopJS.Electron.ElectronContainer.prototype.showNotification = function (options) {
-	notifier = (this.isRemote) ? this.electron.require("node-notifier") : require("node-notifier");
+desktopJS.Electron.ElectronContainer.prototype.showNotification = function (title, options) {
+	notifier = (this.isRemote) ? this.electron.require("electron-notify") : require("electron-notify");
 
 	notifier.notify({
-		title: options.title,
-		message: options.message
+		title: title,
+		text: options.body,
+		onClickFunc: function () { options["notification"].onclick(); }
 	});
 };
 
@@ -72,7 +73,12 @@ visibilityButton.onclick = function () {
 };
 
 notificationButton.onclick = function () {
-	container.showNotification({ title: "Title", message: "Message", url: "notification.html" });
+	Notification.requestPermission().then(function (permission) {
+		if (permission === "granted") {
+			var notification = new Notification("test", { body: "Message", url: "notification.html" });
+			notification.onclick = () => window.alert("Notification clicked");
+		}
+	});
 };
 
 trayIconButton.onclick = function () {

--- a/examples/web/notification.html
+++ b/examples/web/notification.html
@@ -5,10 +5,16 @@
 <head>
     <meta charset="utf-8" />
     <title></title>
+
+    <script>
+        function onNotificationMessage(message) {
+            document.getElementById('message').innerHTML = message;
+        }
+    </script>
 </head>
 
 <body>
-    Notification
+    <div id="message"></div>
 </body>
 
 </html>

--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -189,7 +189,7 @@ export class DefaultContainer extends WebContainerBase {
         return this.wrapWindow(window);
     }
 
-    public showNotification(options: NotificationOptions) {
+    public showNotification(title: string, options?: NotificationOptions) {
         if (!("Notification" in this.globalWindow)) {
             console.warn("Notifications not supported");
             return;
@@ -199,7 +199,7 @@ export class DefaultContainer extends WebContainerBase {
             if (permission === "denied") {
                 console.warn("Notifications not permitted");
             } else if (permission === "granted") {
-                new (<any>this.globalWindow).Notification(options.title, { body: options.message }); // tslint:disable-line
+                new (<any>this.globalWindow).Notification(title, options); // tslint:disable-line
             }
         });
     }

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -130,7 +130,7 @@ export class ElectronContainer extends WebContainerBase {
     protected internalIpc: NodeJS.EventEmitter;
 
     /**
-     * Gets or sets whether to replce the native web Notification API with a wrapper around showNotification.
+     * Gets or sets whether to replace the native web Notification API with a wrapper around showNotification.
      * @type {boolean}
      * @default true
      */

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -1,8 +1,8 @@
 import * as ContainerRegistry from "../registry";
 import { ContainerWindow, PersistedWindowLayout, PersistedWindow } from "../window";
-import { ContainerBase } from "../container";
+import { WebContainerBase } from "../container";
 import { ObjectTransform, PropertyMap } from "../propertymapping";
-import { NotificationOptions } from "../notification";
+import { NotificationOptions, ContainerNotification } from "../notification";
 import { TrayIconDetails } from "../tray";
 import { MenuItem } from "../menu";
 import { MessageBus, MessageBusSubscription, MessageBusOptions } from "../ipc";
@@ -119,7 +119,7 @@ export class ElectronMessageBus implements MessageBus {
 /**
  * @extends ContainerBase
  */
-export class ElectronContainer extends ContainerBase {
+export class ElectronContainer extends WebContainerBase {
     protected isRemote: Boolean = true;
     protected mainWindow: ElectronContainerWindow;
     protected electron: any;
@@ -129,14 +129,21 @@ export class ElectronContainer extends ContainerBase {
     protected menu: any;
     protected internalIpc: NodeJS.EventEmitter;
 
+    /**
+     * Gets or sets whether to replce the native web Notification API with a wrapper around showNotification.
+     * @type {boolean}
+     * @default true
+     */
+    public static replaceNotificationApi: boolean = true;
+
     public static readonly windowOptionsMap: PropertyMap = {
         taskbar: { target: "skipTaskbar", convert: (value: any, from: any, to: any) => { return !value; } }
     };
 
     public windowOptionsMap: PropertyMap = ElectronContainer.windowOptionsMap;
 
-    public constructor(electron?: any, ipc?: NodeJS.EventEmitter | any) {
-        super();
+    public constructor(electron?: any, ipc?: NodeJS.EventEmitter | any, win?: any) {
+        super(win);
         this.hostType = "Electron";
 
         try {
@@ -168,6 +175,23 @@ export class ElectronContainer extends ContainerBase {
             }
         } catch (e) {
             console.error(e);
+        }
+
+        this.registerNotificationsApi();
+    }
+
+    protected registerNotificationsApi() {
+        if (ElectronContainer.replaceNotificationApi && typeof this.globalWindow !== "undefined" && this.globalWindow) {
+            // Define owningContainer for closure to inner class
+            const owningContainer: ElectronContainer = this; // tslint:disable-line
+
+            this.globalWindow["Notification"] = class ElectronNotification extends ContainerNotification {
+                constructor(title: string, options?: NotificationOptions) {
+                    super(title, options);
+                    options["notification"] = this;
+                    owningContainer.showNotification(title, options);
+                }
+            };
         }
     }
 
@@ -215,7 +239,7 @@ export class ElectronContainer extends ContainerBase {
         return this.wrapWindow(electronWindow);
     }
 
-    public showNotification(options: NotificationOptions) {
+    public showNotification(title: string, options?: NotificationOptions) {
         throw new TypeError("showNotification requires an implementation.");
     }
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -137,7 +137,7 @@ export class OpenFinContainer extends WebContainerBase {
     private static readonly trayIconMenuTopOffset: number = 23;
 
     /**
-     * Gets or sets whether to replce the native web Notification API with OpenFin notifications.
+     * Gets or sets whether to replace the native web Notification API with OpenFin notifications.
      * @type {boolean}
      * @default true
      */

--- a/src/container.ts
+++ b/src/container.ts
@@ -56,7 +56,7 @@ export abstract class ContainerBase implements Container {
 
     abstract createWindow(url: string, options?: any): ContainerWindow;
 
-    showNotification(options: NotificationOptions) {
+    showNotification(title: string, options?: NotificationOptions) {
         throw new TypeError("Notifications not supported by this container");
     }
 

--- a/src/notification.ts
+++ b/src/notification.ts
@@ -1,13 +1,50 @@
 export class NotificationOptions {
-    title?: string;
     url?: string;
-    message?: string;
+    body?: string;
 }
 
 export interface ContainerNotificationManager {
     /**
      * Display a notification.
-     * @param {NotificationOptions} options Notification options.
+     * @param {string} title Defines a title for the notification.  Depending on container and choice of notification mechanism, this might not be shown.
+     * @param {NotificationOptions} [options] Notification options.
      */
-    showNotification(options: NotificationOptions);
+    showNotification(title: string, options?: NotificationOptions);
+}
+
+export abstract class ContainerNotification {
+    /**
+     * A string representing the current permission to display notifications.
+     */
+    static permission: string = "granted";
+
+    /**
+     * A handler for the click event.  It is triggered each time the user clicks the notification.
+     */
+    onclick: any;
+
+    /**
+     * A handler for the error event.  It is triggered each the the notification encounters an error.
+     */
+    onerror: any;
+
+    /**
+     * Requests permission from the user to display notifications.
+     * @param {NotificationPermissionCallback} [callback] An optional callback function that is called with the permission value. Depcrecated in favor of the promise return value
+     * @returns {Promise<string>} A Promise that resolves to the permission picked by the user.
+     */
+    static requestPermission(callback?: NotificationPermissionCallback): Promise<string> { // tslint:disable-line
+        if (callback) {
+            callback(ContainerNotification.permission);
+        }
+        return Promise.resolve(ContainerNotification.permission);
+    }
+
+    /**
+     * Creates a new Notification object instance which represents a user notification.
+     * @param {string} title Defines a title for the notification.  Depending on container and choice of notification mechanism, this might not be shown.
+     * @param {NotificationOptions} [options] Notification options.
+     */
+    constructor(title: string, options?: NotificationOptions) { // tslint:disable-line
+    }
 }

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -124,6 +124,7 @@ describe("ElectronContainerWindow", () => {
 describe("ElectronContainer", () => {
     let electron: any;
     let container: ElectronContainer;
+    let globalWindow: any = {};
     let windows: MockWindow[] = [new MockWindow(), new MockWindow()];
 
     beforeEach(() => {
@@ -147,7 +148,7 @@ describe("ElectronContainer", () => {
             require: (type: string) => { return {} },
             getCurrentWindow: () => { return windows[0]; }
         };
-        container = new ElectronContainer(electron, new MockIpc());
+        container = new ElectronContainer(electron, new MockIpc(), globalWindow);
     });
 
     it("hostType is Electron", () => {
@@ -188,9 +189,21 @@ describe("ElectronContainer", () => {
         expect((<any>container).tray).toHaveBeenCalled();
     });
 
-    describe("showNotification", () => {
-        it("Throws Not implemented", () => {
-            expect(() => container.showNotification({})).toThrowError(TypeError);
+    describe("notifications", () => {
+        it("showNotification throws not implemented", () => {
+            expect(() => container.showNotification("title", {})).toThrowError(TypeError);
+        });
+
+        it("requestPermission granted", (done) => {
+            globalWindow["Notification"].requestPermission((permission) => {
+                expect(permission).toEqual("granted");
+            }).then(done);
+        });
+
+        it("notification api delegates to showNotification", () => {
+            spyOn(container, "showNotification").and.stub();
+            new globalWindow["Notification"]("title", { body: "Test message" });
+            expect(container.showNotification).toHaveBeenCalled();;
         });
     });
 

--- a/tslint.json
+++ b/tslint.json
@@ -128,7 +128,7 @@
         "jsdoc-format": true,
         "max-classes-per-file": [  // we generally recommend making one public class per file 
             true,
-            3
+            4
         ],
         "max-file-line-count": [
              true


### PR DESCRIPTION
- Update example Electron notification polyfill to use electron-notify instead of node-notifier
- Change web example to use W3C notification api instead of container.showNotification directly
- Change showNotification signature to match notification constructor parameters (separate title parameter)
- Change NotificationsOptions message to body to be consistent with W3C notifications and not any particular container.  This requires transforming properties for OpenFin notifications.
- Update OpenFin example notification.html to display notification message in toast
- Polyfill notification api in OpenFin and Electron to invoke common container.showNotification
- Change base class of ElectronContainer to WebContainerBase to get "globalWindow" property via dependency injection (for unit tests) or run-time discovery.  The globalWindow is necessary to provide the notification api polyfill in renderer process.  This will be ignored in the main process.