### PR TITLE
Remove doc generation from default bundle since it slows down the build and move to Travis CI as a second script step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
 
 script:
   - npm run build
+  - npm run docs
 
 after_success:
   - "./node_modules/.bin/codecov -f ./build/coverage/*.json"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -203,7 +203,7 @@ gulp.task("server", function () {
         }));
 });
 
-gulp.task('bundle', ['tslint', 'clean', 'build', 'test', 'dts', 'compress', 'docs']);
+gulp.task('bundle', ['tslint', 'clean', 'build', 'test', 'dts', 'compress']);
 
 gulp.task('watch', function () {
     gulp.watch(src, ['bundle']);


### PR DESCRIPTION
Local builds were too slow having to generate unnecessary docs every time