### PR TITLE
Use fin.desktop.Application.getCurrent().getWindow() 

### DIFF
--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -251,7 +251,7 @@ export class OpenFinContainer extends WebContainerBase {
 
     public getMainWindow(): ContainerWindow {
         if (!this.mainWindow) {
-            this.mainWindow = new OpenFinContainerWindow(this.desktop.Window.getCurrent().getParentWindow());
+            this.mainWindow = this.wrapWindow(this.desktop.Application.getCurrent().getWindow());
         }
 
         return this.mainWindow;
@@ -405,7 +405,7 @@ export class OpenFinContainer extends WebContainerBase {
     public getAllWindows(): Promise<ContainerWindow[]> {
         return new Promise<ContainerWindow[]>((resolve, reject) => {
             this.desktop.Application.getCurrent().getChildWindows(windows => {
-                windows.push(this.desktop.Window.getCurrent());
+                windows.push(this.desktop.Application.getCurrent().getWindow());
                 resolve(windows.map(window => this.wrapWindow(window)));
             }, reject);
         });

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -5,10 +5,9 @@ import { MenuItem } from "../../../src/menu";
 class MockDesktop {
     public static application: any = {
         uuid: "uuid",
-        getChildWindows(callback) {
-            callback([MockWindow.singleton]);
-        },
-        setTrayIcon() { }
+        getChildWindows(callback) { callback([MockWindow.singleton]); },
+        setTrayIcon() { },
+        getWindow() { return MockWindow.singleton; }
     }
 
     Window: any = MockWindow;
@@ -243,7 +242,7 @@ describe("OpenFinContainer", () => {
         });
 
         describe("window management", () => {
-            it ("getAllWindows returns wrapped native windows", (done) => {
+            it("getAllWindows returns wrapped native windows", (done) => {
                 container.getAllWindows().then(windows => {
                     expect(windows).not.toBeNull();
                     expect(windows.length).toEqual(2);


### PR DESCRIPTION
OpenFin getMainWindow:
- Use Application.getCurrent().getWindow() in place of Window.getCurrent().getParentWindow()

OpenFin getAllWindows:
- Fix bug with adding current window to list instead of the main parent window.

Fixes #41