### PR TITLE
Add instance event handlers to ContainerWindow

### DIFF
--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -7,14 +7,16 @@ import { MessageBus, MessageBusSubscription, MessageBusOptions } from "../ipc";
 
 declare var Notification: any;
 
+const windowEventMap = {
+    close: "unload"
+};
+
 /**
  * @augments ContainerWindow
  */
-export class DefaultContainerWindow implements ContainerWindow {
-    public containerWindow: any;
-
+export class DefaultContainerWindow extends ContainerWindow {
     public constructor(wrap: any) {
-        this.containerWindow = wrap;
+        super(wrap);
     }
 
     public focus(): Promise<void> {
@@ -56,6 +58,14 @@ export class DefaultContainerWindow implements ContainerWindow {
             this.containerWindow.resizeTo(bounds.width, bounds.height);
             resolve();
         });
+    }
+
+    protected attachListener(eventName: string, listener: (...args: any[]) => void): void {
+        this.containerWindow.addEventListener(windowEventMap[eventName] || eventName, listener);
+    }
+
+    protected detachListener(eventName: string, listener: (...args: any[]) => void): void {
+        this.containerWindow.removeEventListener(windowEventMap[eventName] || eventName, listener);
     }
 }
 

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -18,14 +18,14 @@ ContainerRegistry.registerContainer("Electron", {
     create: () => new ElectronContainer()
 });
 
+const windowEventMap = {};
+
 /**
  * @augments ContainerWindow
  */
-export class ElectronContainerWindow implements ContainerWindow {
-    public containerWindow: any;
-
+export class ElectronContainerWindow extends ContainerWindow {
     public constructor(wrap: any) {
-        this.containerWindow = wrap;
+        super(wrap);
     }
 
     public focus(): Promise<void> {
@@ -73,6 +73,14 @@ export class ElectronContainerWindow implements ContainerWindow {
             this.containerWindow.setBounds(bounds);
             resolve();
         });
+    }
+
+    protected attachListener(eventName: string, listener: (...args: any[]) => void): void {
+        this.containerWindow.addListener(windowEventMap[eventName] || eventName, listener);
+    }
+
+    protected detachListener(eventName: string, listener: (...args: any[]) => void): void {
+        this.containerWindow.removeListener(windowEventMap[eventName] || eventName, listener);
     }
 }
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -13,14 +13,23 @@ ContainerRegistry.registerContainer("OpenFin", {
     create: () => new OpenFinContainer()
 });
 
+const windowEventMap = {
+    move: "bounds-changing",
+    resize: "bounds-changed",
+    close: "close-requested",
+    focus: "focused",
+    blur: "blurred",
+    maximize: "maximized",
+    minimize: "minimized",
+    restore: "restored"
+};
+
 /**
  * @augments ContainerWindow
  */
-export class OpenFinContainerWindow implements ContainerWindow {
-    public containerWindow: any;
-
+export class OpenFinContainerWindow extends ContainerWindow {
     public constructor(wrap: any) {
-        this.containerWindow = wrap;
+        super(wrap);
     }
 
     public focus(): Promise<void> {
@@ -74,6 +83,14 @@ export class OpenFinContainerWindow implements ContainerWindow {
         return new Promise<void>((resolve, reject) => {
             this.containerWindow.setBounds(bounds.x, bounds.y, bounds.width, bounds.height, resolve, reject);
         });
+    }
+
+    protected attachListener(eventName: string, listener: (...args: any[]) => void): void {
+        this.containerWindow.addEventListener(windowEventMap[eventName] || eventName, listener);
+    }
+
+    protected detachListener(eventName: string, listener: (...args: any[]) => void): any {
+        this.containerWindow.removeEventListener(windowEventMap[eventName] || eventName, listener);
     }
 }
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,0 +1,83 @@
+export class EventArgs {
+    public readonly sender: any;
+
+    public readonly innerEvent: any;
+
+    public readonly name: string;
+
+    constructor(sender: any, name: string, innerEvent: any) {
+        this.sender = sender;
+        this.name = name;
+        this.innerEvent = innerEvent;
+    }
+}
+
+export abstract class EventEmitter {
+    private eventListeners: Map<string, ((event: EventArgs) => void)[]> = new Map();
+
+    private wrappedListeners: Map<(event: EventArgs) => void, (event: EventArgs) => void> = new Map();
+
+    /**
+     * Registers an event listener on the specified event.
+     * @param eventName {string} eventName The type of the event.
+     * @param listener {(event: EventArgs) => void} The event handler function.
+     */
+    public addListener(eventName: string, listener: (event: EventArgs) => void): any {
+        (this.eventListeners[eventName] = this.eventListeners[eventName] || []).push(listener);
+        return this;
+    }
+
+    protected registerAndWrapListener(eventName: string, listener: (event: EventArgs) => void): (event: EventArgs) => void {
+        const callback = (event) => {
+            listener(new EventArgs(this, eventName, event));
+        };
+
+        this.wrappedListeners.set(listener, callback);
+        return callback;
+    }
+
+    protected unwrapAndUnRegisterListener(listener: (event: EventArgs) => void): (event: EventArgs) => void {
+        const callback = this.wrappedListeners.get(listener);
+        if (callback) {
+            this.wrappedListeners.delete(listener);
+        }
+
+        return callback;
+    }
+
+    /**
+     * Removes a previous registered event listener from the specified event.
+     * @param eventName {string} eventName The type of the event.
+     * @param listener {(event: EventArgs) => void} The event handler function.
+     */
+    public removeListener(eventName: string, listener: (event: EventArgs) => void): any {
+        const listeners = this.listeners(eventName);
+
+        if (listeners) {
+            const i = listeners.indexOf(listener);
+            if (i >= 0) {
+                listeners.splice(i, 1);
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * Gets an array of listeners for a specific event type.
+     * @param eventName {string} eventName The type of the event.
+     */
+    public listeners(eventName: string): ((event: EventArgs) => void)[] {
+        return (this.eventListeners[eventName] || []);
+    }
+
+    /**
+     * Invokes each listener registered for the specified event type.
+     * @param eventName {string} eventName The type of the event.
+     */
+    public emit(eventName: string, eventArgs: EventArgs) {
+        for (const listener of this.listeners(eventName)) {
+            listener(eventArgs);
+        }
+    }
+}

--- a/tests/unit/Default/default.spec.ts
+++ b/tests/unit/Default/default.spec.ts
@@ -12,7 +12,7 @@ class MockWindow {
     public postMessage(message: string, origin: string): void { };
     public moveTo(x: number, y: number): void { };
     public resizeTo(width: number, height: number): void { }
-    public screenX: any =  0;
+    public screenX: any = 0;
     public screenY: any = 1;
     public outerWidth: any = 2;
     public outerHeight: any = 3;
@@ -86,6 +86,36 @@ describe("DefaultContainerWindow", () => {
             expect(win.containerWindow.resizeTo).toHaveBeenCalledWith(2, 3);
         }).then(done);
     });
+
+    describe("addListener", () => {
+        it("addListener calls underlying window addEventListener with mapped event name", () => {
+            spyOn(win.containerWindow, "addEventListener").and.callThrough()
+            win.addListener("close", () => { });
+            expect(win.containerWindow.addEventListener).toHaveBeenCalledWith("unload", jasmine.any(Function));
+        });
+
+        it("addListener calls underlying window addEventListener with unmapped event name", () => {
+            const unmappedEvent = "resize";
+            spyOn(win.containerWindow, "addEventListener").and.callThrough()
+            win.addListener(unmappedEvent, () => { });
+            expect(win.containerWindow.addEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
+        });
+    });
+
+    describe("removeListener", () => {
+        it("removeListener calls underlying window removeEventListener with mapped event name", () => {
+            spyOn(win.containerWindow, "removeEventListener").and.callThrough()
+            win.removeListener("close", () => { });
+            expect(win.containerWindow.removeEventListener).toHaveBeenCalledWith("unload", jasmine.any(Function));
+        });
+
+        it("removeListener calls underlying window removeEventListener with unmapped event name", () => {
+            const unmappedEvent = "resize";
+            spyOn(win.containerWindow, "removeEventListener").and.callThrough()
+            win.removeListener(unmappedEvent, () => { });
+            expect(win.containerWindow.removeEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
+        });
+    });
 });
 
 describe("DefaultContainer", () => {
@@ -158,7 +188,7 @@ describe("DefaultContainer", () => {
         expect(win).toBeDefined();
         expect(win.containerWindow).toEqual(window);
     });
-   
+
 
     describe("Notifications", () => {
         it("showNotification warns about not being implemented", () => {
@@ -188,7 +218,7 @@ describe("DefaultContainer", () => {
                 "1": new MockWindow(),
                 "2": new MockWindow()
             };
-            
+
             let container: DefaultContainer = new DefaultContainer(window);
             container.getAllWindows().then(wins => {
                 expect(wins).not.toBeNull();
@@ -196,7 +226,7 @@ describe("DefaultContainer", () => {
                 done();
             });
         });
-        
+
         it("closeAllWindows invokes window.close", (done) => {
             let container: DefaultContainer = new DefaultContainer(window);
             spyOn(window, "close").and.callThrough();

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -30,6 +30,10 @@ class MockWindow {
     public getBounds(): any { return { x: 0, y: 1, width: 2, height: 3 }; }
 
     public setBounds(bounds: {x: number, y: number, width: number, height: number}): void { }
+
+    public addListener(eventName: string, listener: any): void { }
+    
+    public removeListener(eventName: string, listener: any): void { }
 }
 
 class MockCapture {
@@ -137,6 +141,18 @@ describe("ElectronContainerWindow", () => {
             win.setBounds(bounds).then(() => {
                 expect(win.containerWindow.setBounds).toHaveBeenCalledWith(bounds);
             }).then(done);
+        });
+
+        it("addListener calls underlying Electron window addListener", () => {
+            spyOn(win.containerWindow, "addListener").and.callThrough()
+            win.addListener("move", () => {});
+            expect(win.containerWindow.addListener).toHaveBeenCalledWith("move", jasmine.any(Function));
+        });
+
+        it("removeListener calls underlying Electron window removeListener", () => {
+            spyOn(win.containerWindow, "removeListener").and.callThrough()
+            win.removeListener("move", () => {});
+            expect(win.containerWindow.removeListener).toHaveBeenCalledWith("move", jasmine.any(Function));
         });
     });
 });

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -94,6 +94,10 @@ class MockWindow {
         callback({ url: "url" });
         return {};
     }
+
+    addEventListener(eventName: string, listener: any): void { }
+
+    removeEventListener(eventName: string, listener: any): void { }
 }
 
 describe("OpenFinContainerWindow", () => {
@@ -195,6 +199,36 @@ describe("OpenFinContainerWindow", () => {
             win.setBounds({ x: 0, y: 1, width: 2, height: 3 }).then(() => {
                 expect(win.containerWindow.setBounds).toHaveBeenCalledWith(0, 1, 2, 3, jasmine.any(Function), jasmine.any(Function));
             }).then(done);
+        });
+
+        describe("addListener", () => {
+            it("addListener calls underlying OpenFin window addEventListener with mapped event name", () => {
+                spyOn(win.containerWindow, "addEventListener").and.callThrough()
+                win.addListener("move", () => { });
+                expect(win.containerWindow.addEventListener).toHaveBeenCalledWith("bounds-changing", jasmine.any(Function));
+            });
+
+            it("addListener calls underlying OpenFin window addEventListener with unmapped event name", () => {
+                const unmappedEvent = "closed";
+                spyOn(win.containerWindow, "addEventListener").and.callThrough()
+                win.addListener(unmappedEvent, () => { });
+                expect(win.containerWindow.addEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
+            });
+        });
+
+        describe("removeListener", () => {
+            it("removeListener calls underlying OpenFin window removeEventListener with mapped event name", () => {
+                spyOn(win.containerWindow, "removeEventListener").and.callThrough()
+                win.removeListener("move", () => { });
+                expect(win.containerWindow.removeEventListener).toHaveBeenCalledWith("bounds-changing", jasmine.any(Function));
+            });
+
+            it("removeListener calls underlying OpenFin window removeEventListener with unmapped event name", () => {
+                const unmappedEvent = "closed";
+                spyOn(win.containerWindow, "removeEventListener").and.callThrough()
+                win.removeListener(unmappedEvent, () => { });
+                expect(win.containerWindow.removeEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
+            });
         });
     });
 });

--- a/tests/unit/events.spec.ts
+++ b/tests/unit/events.spec.ts
@@ -1,0 +1,63 @@
+import { EventEmitter, EventArgs } from "../../src/events";
+
+class TestEmitter extends EventEmitter {
+}
+
+describe("EventArgs", () => {
+    it("ctor params set on properties", () => {
+        const sender = {};
+        const eventName = "TestEvent";
+        const innerEvent = {};
+        const args = new EventArgs(sender, eventName, innerEvent);
+        expect(args.sender).toEqual(sender);
+        expect(args.name).toEqual(eventName);
+        expect(args.innerEvent).toEqual(innerEvent);
+    });
+});
+
+describe("EventEmitter", () => {
+    let emitter;
+
+    beforeEach(() => {
+        emitter = new TestEmitter();
+    });
+
+    it("addListener adds callback to listeners", () => {
+        expect(emitter.listeners("TestEvent").length).toEqual(0);
+        emitter.addListener("TestEvent", (event: EventArgs) => { });
+        expect(emitter.listeners("TestEvent").length).toEqual(1);
+    });
+
+    it("removeListener removes callback to listeners", () => {
+        expect(emitter.listeners("TestEvent").length).toEqual(0);
+        const callback = (event: EventArgs) => { };
+        emitter.addListener("TestEvent", callback);
+        expect(emitter.listeners("TestEvent").length).toEqual(1);
+        emitter.removeListener("TestEvent", callback);
+        expect(emitter.listeners("TestEvent").length).toEqual(0);
+    });
+
+    it("emit invokes callbacks", (done) => {
+        const args = new EventArgs(this, "TestEvent", {});
+        const callback = (event: EventArgs) => {
+            expect(event).toEqual(args);
+            done();
+        };
+        emitter.addListener(args.type, callback);
+        emitter.emit(args.type, args);
+    });
+
+    it("registerAndWrapListener", (done) => {
+        const listener = (event: EventArgs) => { done(); };
+        const wrappedCallback = emitter.registerAndWrapListener("TestEvent", listener);
+        expect(wrappedCallback).not.toBeNull();
+        emitter.addListener("TestEvent", wrappedCallback);        
+        emitter.emit("TestEvent", {});
+    });
+
+    it("unwrapAndUnRegisterListener returns mapped callback", () => {
+        const listener = (event: EventArgs) => { };
+        const wrappedCallback = emitter.registerAndWrapListener("TestEvent", listener);
+        expect(emitter.unwrapAndUnRegisterListener(listener)).toEqual(wrappedCallback);
+    });
+});


### PR DESCRIPTION
- Add abstract EventEmitter
- Change ContainerWindow from interface to abstract class extending EventEmitter
- Change concrete ContainerWindow subclasses to now extend ContainerWindow vs implement
