### PR TITLE
Rename ContainerWindow containerWindow to innerWindow

### DIFF
--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -20,7 +20,7 @@ export class DefaultContainerWindow extends ContainerWindow {
     }
 
     public focus(): Promise<void> {
-        this.containerWindow.focus();
+        this.innerWindow.focus();
         return Promise.resolve();
     }
 
@@ -33,7 +33,7 @@ export class DefaultContainerWindow extends ContainerWindow {
     }
 
     public close(): Promise<void> {
-        this.containerWindow.close();
+        this.innerWindow.close();
         return Promise.resolve();
     }
 
@@ -48,24 +48,24 @@ export class DefaultContainerWindow extends ContainerWindow {
 
     public getBounds(): Promise<Rectangle> {
         return new Promise<Rectangle>(resolve => {
-            resolve(new Rectangle(this.containerWindow.screenX, this.containerWindow.screenY, this.containerWindow.outerWidth, this.containerWindow.outerHeight));
+            resolve(new Rectangle(this.innerWindow.screenX, this.innerWindow.screenY, this.innerWindow.outerWidth, this.innerWindow.outerHeight));
         });
     }
 
     public setBounds(bounds: Rectangle): Promise<void> {
         return new Promise<void>(resolve => {
-            this.containerWindow.moveTo(bounds.x, bounds.y);
-            this.containerWindow.resizeTo(bounds.width, bounds.height);
+            this.innerWindow.moveTo(bounds.x, bounds.y);
+            this.innerWindow.resizeTo(bounds.width, bounds.height);
             resolve();
         });
     }
 
     protected attachListener(eventName: string, listener: (...args: any[]) => void): void {
-        this.containerWindow.addEventListener(windowEventMap[eventName] || eventName, listener);
+        this.innerWindow.addEventListener(windowEventMap[eventName] || eventName, listener);
     }
 
     protected detachListener(eventName: string, listener: (...args: any[]) => void): void {
-        this.containerWindow.removeEventListener(windowEventMap[eventName] || eventName, listener);
+        this.innerWindow.removeEventListener(windowEventMap[eventName] || eventName, listener);
     }
 }
 

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -29,34 +29,34 @@ export class ElectronContainerWindow extends ContainerWindow {
     }
 
     public focus(): Promise<void> {
-        this.containerWindow.focus();
+        this.innerWindow.focus();
         return Promise.resolve();
     }
 
     public show(): Promise<void> {
-        this.containerWindow.show();
+        this.innerWindow.show();
         return Promise.resolve();
     }
 
     public hide(): Promise<void> {
-        this.containerWindow.hide();
+        this.innerWindow.hide();
         return Promise.resolve();
     }
 
     public close(): Promise<void> {
-        this.containerWindow.close();
+        this.innerWindow.close();
         return Promise.resolve();
     }
 
     public isShowing(): Promise<boolean> {
         return new Promise<boolean>((resolve, reject) => {
-            resolve(this.containerWindow.isVisible());
+            resolve(this.innerWindow.isVisible());
         });
     }
 
     public getSnapshot(): Promise<string> {
         return new Promise<string>((resolve, reject) => {
-            this.containerWindow.capturePage((snapshot) => {
+            this.innerWindow.capturePage((snapshot) => {
                 resolve("data:image/png;base64," + snapshot.toPNG().toString("base64"));
             });
         });
@@ -64,23 +64,23 @@ export class ElectronContainerWindow extends ContainerWindow {
 
     public getBounds(): Promise<Rectangle> {
         return new Promise<Rectangle>(resolve => {
-            resolve(this.containerWindow.getBounds());
+            resolve(this.innerWindow.getBounds());
         });
     }
 
     public setBounds(bounds: Rectangle): Promise<void> {
         return new Promise<void>(resolve => {
-            this.containerWindow.setBounds(bounds);
+            this.innerWindow.setBounds(bounds);
             resolve();
         });
     }
 
     protected attachListener(eventName: string, listener: (...args: any[]) => void): void {
-        this.containerWindow.addListener(windowEventMap[eventName] || eventName, listener);
+        this.innerWindow.addListener(windowEventMap[eventName] || eventName, listener);
     }
 
     protected detachListener(eventName: string, listener: (...args: any[]) => void): void {
-        this.containerWindow.removeListener(windowEventMap[eventName] || eventName, listener);
+        this.innerWindow.removeListener(windowEventMap[eventName] || eventName, listener);
     }
 }
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -34,37 +34,37 @@ export class OpenFinContainerWindow extends ContainerWindow {
 
     public focus(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            this.containerWindow.focus(resolve, reject);
+            this.innerWindow.focus(resolve, reject);
         });
     }
 
     public show(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            this.containerWindow.show(resolve, reject);
+            this.innerWindow.show(resolve, reject);
         });
     }
 
     public hide(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            this.containerWindow.hide(resolve, reject);
+            this.innerWindow.hide(resolve, reject);
         });
     }
 
     public close(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            this.containerWindow.close(false, resolve, reject);
+            this.innerWindow.close(false, resolve, reject);
         });
     }
 
     public isShowing(): Promise<boolean> {
         return new Promise<boolean>((resolve, reject) => {
-            this.containerWindow.isShowing(resolve, reject);
+            this.innerWindow.isShowing(resolve, reject);
         });
     }
 
     public getSnapshot(): Promise<string> {
         return new Promise<string>((resolve, reject) => {
-            this.containerWindow.getSnapshot(
+            this.innerWindow.getSnapshot(
                 (snapshot) => resolve("data:image/png;base64," + snapshot),
                 (reason) => reject(reason)
             );
@@ -73,7 +73,7 @@ export class OpenFinContainerWindow extends ContainerWindow {
 
     public getBounds(): Promise<Rectangle> {
         return new Promise<Rectangle>((resolve, reject) => {
-            this.containerWindow.getBounds(
+            this.innerWindow.getBounds(
                 bounds => resolve(new Rectangle(bounds.left, bounds.top, bounds.width, bounds.height)),
                 reject);
         });
@@ -81,16 +81,16 @@ export class OpenFinContainerWindow extends ContainerWindow {
 
     public setBounds(bounds: Rectangle): Promise<void> {
         return new Promise<void>((resolve, reject) => {
-            this.containerWindow.setBounds(bounds.x, bounds.y, bounds.width, bounds.height, resolve, reject);
+            this.innerWindow.setBounds(bounds.x, bounds.y, bounds.width, bounds.height, resolve, reject);
         });
     }
 
     protected attachListener(eventName: string, listener: (...args: any[]) => void): void {
-        this.containerWindow.addEventListener(windowEventMap[eventName] || eventName, listener);
+        this.innerWindow.addEventListener(windowEventMap[eventName] || eventName, listener);
     }
 
     protected detachListener(eventName: string, listener: (...args: any[]) => void): any {
-        this.containerWindow.removeEventListener(windowEventMap[eventName] || eventName, listener);
+        this.innerWindow.removeEventListener(windowEventMap[eventName] || eventName, listener);
     }
 }
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -47,11 +47,11 @@ export type WindowEventType =
 /** Represents a container window. */
 export abstract class ContainerWindow extends EventEmitter {
     /** The underlying concrete container window. */
-    public readonly containerWindow: any;
+    public readonly innerWindow: any;
 
     public constructor(wrap: any) {
         super();
-        this.containerWindow = wrap;
+        this.innerWindow = wrap;
     }
 
     /** Gives focus to the window. */

--- a/tests/unit/Default/default.spec.ts
+++ b/tests/unit/Default/default.spec.ts
@@ -79,41 +79,41 @@ describe("DefaultContainerWindow", () => {
     });
 
     it("setBounds sets underlying window position", (done) => {
-        spyOn(win.containerWindow, "moveTo").and.callThrough()
-        spyOn(win.containerWindow, "resizeTo").and.callThrough();
+        spyOn(win.innerWindow, "moveTo").and.callThrough()
+        spyOn(win.innerWindow, "resizeTo").and.callThrough();
         win.setBounds({ x: 0, y: 1, width: 2, height: 3 }).then(() => {
-            expect(win.containerWindow.moveTo).toHaveBeenCalledWith(0, 1);
-            expect(win.containerWindow.resizeTo).toHaveBeenCalledWith(2, 3);
+            expect(win.innerWindow.moveTo).toHaveBeenCalledWith(0, 1);
+            expect(win.innerWindow.resizeTo).toHaveBeenCalledWith(2, 3);
         }).then(done);
     });
 
     describe("addListener", () => {
         it("addListener calls underlying window addEventListener with mapped event name", () => {
-            spyOn(win.containerWindow, "addEventListener").and.callThrough()
+            spyOn(win.innerWindow, "addEventListener").and.callThrough()
             win.addListener("close", () => { });
-            expect(win.containerWindow.addEventListener).toHaveBeenCalledWith("unload", jasmine.any(Function));
+            expect(win.innerWindow.addEventListener).toHaveBeenCalledWith("unload", jasmine.any(Function));
         });
 
         it("addListener calls underlying window addEventListener with unmapped event name", () => {
             const unmappedEvent = "resize";
-            spyOn(win.containerWindow, "addEventListener").and.callThrough()
+            spyOn(win.innerWindow, "addEventListener").and.callThrough()
             win.addListener(unmappedEvent, () => { });
-            expect(win.containerWindow.addEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
+            expect(win.innerWindow.addEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
         });
     });
 
     describe("removeListener", () => {
         it("removeListener calls underlying window removeEventListener with mapped event name", () => {
-            spyOn(win.containerWindow, "removeEventListener").and.callThrough()
+            spyOn(win.innerWindow, "removeEventListener").and.callThrough()
             win.removeListener("close", () => { });
-            expect(win.containerWindow.removeEventListener).toHaveBeenCalledWith("unload", jasmine.any(Function));
+            expect(win.innerWindow.removeEventListener).toHaveBeenCalledWith("unload", jasmine.any(Function));
         });
 
         it("removeListener calls underlying window removeEventListener with unmapped event name", () => {
             const unmappedEvent = "resize";
-            spyOn(win.containerWindow, "removeEventListener").and.callThrough()
+            spyOn(win.innerWindow, "removeEventListener").and.callThrough()
             win.removeListener(unmappedEvent, () => { });
-            expect(win.containerWindow.removeEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
+            expect(win.innerWindow.removeEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
         });
     });
 });
@@ -161,14 +161,14 @@ describe("DefaultContainer", () => {
         });
 
         it("Window is addded to windows", () => {
-            let newWin: any = container.createWindow("url").containerWindow;
+            let newWin: any = container.createWindow("url").innerWindow;
             expect(newWin[DefaultContainer.windowUuidPropertyKey]).toBeDefined();
             expect(newWin[DefaultContainer.windowsPropertyKey]).toBeDefined();
             expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeDefined();
         });
 
         it("Window is removed from windows on close", () => {
-            let newWin: any = container.createWindow("url").containerWindow;
+            let newWin: any = container.createWindow("url").innerWindow;
             expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeDefined();
             newWin.listener("unload", {});
             expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeUndefined();
@@ -179,14 +179,14 @@ describe("DefaultContainer", () => {
         let container: DefaultContainer = new DefaultContainer(window);
         let win: DefaultContainerWindow = container.getMainWindow();
         expect(win).toBeDefined();
-        expect(win.containerWindow).toEqual(window);
+        expect(win.innerWindow).toEqual(window);
     });
 
     it("getCurrentWindow returns DefaultContainerWindow wrapping scoped window", () => {
         let container: DefaultContainer = new DefaultContainer(window);
         let win: DefaultContainerWindow = container.getCurrentWindow();
         expect(win).toBeDefined();
-        expect(win.containerWindow).toEqual(window);
+        expect(win.innerWindow).toEqual(window);
     });
 
 

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -64,8 +64,8 @@ describe("ElectronContainerWindow", () => {
 
     it("Wrapped window is retrievable", () => {
         expect(win).toBeDefined();
-        expect(win.containerWindow).toBeDefined();
-        expect(win.containerWindow).toEqual(innerWin);
+        expect(win.innerWindow).toBeDefined();
+        expect(win.innerWindow).toEqual(innerWin);
     });
 
     describe("Window members", () => {
@@ -136,23 +136,23 @@ describe("ElectronContainerWindow", () => {
         });
 
         it("setBounds sets underlying window position", (done) => {
-            spyOn(win.containerWindow, "setBounds").and.callThrough()
+            spyOn(win.innerWindow, "setBounds").and.callThrough()
             const bounds = { x: 0, y: 1, width: 2, height: 3 };
             win.setBounds(bounds).then(() => {
-                expect(win.containerWindow.setBounds).toHaveBeenCalledWith(bounds);
+                expect(win.innerWindow.setBounds).toHaveBeenCalledWith(bounds);
             }).then(done);
         });
 
         it("addListener calls underlying Electron window addListener", () => {
-            spyOn(win.containerWindow, "addListener").and.callThrough()
+            spyOn(win.innerWindow, "addListener").and.callThrough()
             win.addListener("move", () => {});
-            expect(win.containerWindow.addListener).toHaveBeenCalledWith("move", jasmine.any(Function));
+            expect(win.innerWindow.addListener).toHaveBeenCalledWith("move", jasmine.any(Function));
         });
 
         it("removeListener calls underlying Electron window removeListener", () => {
-            spyOn(win.containerWindow, "removeListener").and.callThrough()
+            spyOn(win.innerWindow, "removeListener").and.callThrough()
             win.removeListener("move", () => {});
-            expect(win.containerWindow.removeListener).toHaveBeenCalledWith("move", jasmine.any(Function));
+            expect(win.innerWindow.removeListener).toHaveBeenCalledWith("move", jasmine.any(Function));
         });
     });
 });
@@ -211,7 +211,7 @@ describe("ElectronContainer", () => {
 
         expect(win).toBeDefined();
         expect(electron.getCurrentWindow).toHaveBeenCalled();
-        expect(win.containerWindow).toEqual(innerWin);
+        expect(win.innerWindow).toEqual(innerWin);
     });
 
     it("getCurrentWindow returns wrapped inner getCurrentWindow", () => {
@@ -221,7 +221,7 @@ describe("ElectronContainer", () => {
 
         expect(win).toBeDefined();
         expect(electron.getCurrentWindow).toHaveBeenCalled();
-        expect(win.containerWindow).toEqual(innerWin);
+        expect(win.innerWindow).toEqual(innerWin);
     });
 
     it("createWindow", () => {

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -111,8 +111,8 @@ describe("OpenFinContainerWindow", () => {
 
     it("Wrapped window is retrievable", () => {
         expect(win).toBeDefined();
-        expect(win.containerWindow).toBeDefined();
-        expect(win.containerWindow).toEqual(innerWin);
+        expect(win.innerWindow).toBeDefined();
+        expect(win.innerWindow).toEqual(innerWin);
     });
 
     it("focus", (done) => {
@@ -195,39 +195,39 @@ describe("OpenFinContainerWindow", () => {
         });
 
         it("setBounds sets underlying window position", (done) => {
-            spyOn(win.containerWindow, "setBounds").and.callThrough()
+            spyOn(win.innerWindow, "setBounds").and.callThrough()
             win.setBounds({ x: 0, y: 1, width: 2, height: 3 }).then(() => {
-                expect(win.containerWindow.setBounds).toHaveBeenCalledWith(0, 1, 2, 3, jasmine.any(Function), jasmine.any(Function));
+                expect(win.innerWindow.setBounds).toHaveBeenCalledWith(0, 1, 2, 3, jasmine.any(Function), jasmine.any(Function));
             }).then(done);
         });
 
         describe("addListener", () => {
             it("addListener calls underlying OpenFin window addEventListener with mapped event name", () => {
-                spyOn(win.containerWindow, "addEventListener").and.callThrough()
+                spyOn(win.innerWindow, "addEventListener").and.callThrough()
                 win.addListener("move", () => { });
-                expect(win.containerWindow.addEventListener).toHaveBeenCalledWith("bounds-changing", jasmine.any(Function));
+                expect(win.innerWindow.addEventListener).toHaveBeenCalledWith("bounds-changing", jasmine.any(Function));
             });
 
             it("addListener calls underlying OpenFin window addEventListener with unmapped event name", () => {
                 const unmappedEvent = "closed";
-                spyOn(win.containerWindow, "addEventListener").and.callThrough()
+                spyOn(win.innerWindow, "addEventListener").and.callThrough()
                 win.addListener(unmappedEvent, () => { });
-                expect(win.containerWindow.addEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
+                expect(win.innerWindow.addEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
             });
         });
 
         describe("removeListener", () => {
             it("removeListener calls underlying OpenFin window removeEventListener with mapped event name", () => {
-                spyOn(win.containerWindow, "removeEventListener").and.callThrough()
+                spyOn(win.innerWindow, "removeEventListener").and.callThrough()
                 win.removeListener("move", () => { });
-                expect(win.containerWindow.removeEventListener).toHaveBeenCalledWith("bounds-changing", jasmine.any(Function));
+                expect(win.innerWindow.removeEventListener).toHaveBeenCalledWith("bounds-changing", jasmine.any(Function));
             });
 
             it("removeListener calls underlying OpenFin window removeEventListener with unmapped event name", () => {
                 const unmappedEvent = "closed";
-                spyOn(win.containerWindow, "removeEventListener").and.callThrough()
+                spyOn(win.innerWindow, "removeEventListener").and.callThrough()
                 win.removeListener(unmappedEvent, () => { });
-                expect(win.containerWindow.removeEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
+                expect(win.innerWindow.removeEventListener).toHaveBeenCalledWith(unmappedEvent, jasmine.any(Function));
             });
         });
     });
@@ -250,13 +250,13 @@ describe("OpenFinContainer", () => {
     it("getMainWindow returns wrapped inner window", () => {
         const win: OpenFinContainerWindow = container.getMainWindow();
         expect(win).toBeDefined();
-        expect(win.containerWindow).toEqual(MockWindow.singleton);
+        expect(win.innerWindow).toEqual(MockWindow.singleton);
     });
 
     it("getCurrentWindow returns wrapped inner window", () => {
         const win: OpenFinContainerWindow = container.getCurrentWindow();
         expect(win).toBeDefined();
-        expect(win.containerWindow).toEqual(MockWindow.singleton);
+        expect(win.innerWindow).toEqual(MockWindow.singleton);
     });
 
     describe("createWindow", () => {
@@ -308,7 +308,7 @@ describe("OpenFinContainer", () => {
                 container.getAllWindows().then(windows => {
                     expect(windows).not.toBeNull();
                     expect(windows.length).toEqual(2);
-                    expect(windows[0].containerWindow).toEqual(MockWindow.singleton);
+                    expect(windows[0].innerWindow).toEqual(MockWindow.singleton);
                     done();
                 });
             });


### PR DESCRIPTION
Avoid confusion of type ContainerWindow having a property containerWindow which is the concrete internal window and nothing related to the type ContainerWindow at all.