### PR TITLE
Create event framework for container instances

### DIFF
--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -42,6 +42,11 @@ desktopJS.Electron.ElectronContainer.prototype.showNotification = function (titl
 
 document.addEventListener("DOMContentLoaded", function (event) {
 	hostName.innerHTML = container.hostType + "<br />" + container.uuid;
+
+	container.addListener("window-created", (e) => console.log("Window created"));
+	container.addListener("layout-loaded", (e) => console.log("Layout loaded"));
+	container.addListener("layout-saved", (e) => console.log("Layout saved"));
+
 	subscribe();
 });
 

--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -214,7 +214,9 @@ export class DefaultContainer extends WebContainerBase {
         // Propagate the global windows object to the new window
         window[DefaultContainer.windowsPropertyKey] = windows;
 
-        return this.wrapWindow(window);
+        const newWindow = this.wrapWindow(window);
+        this.emit("window-created", { sender: this, name: "window-created", window: newWindow });
+        return newWindow;
     }
 
     public showNotification(title: string, options?: NotificationOptions) {

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -261,7 +261,9 @@ export class ElectronContainer extends WebContainerBase {
 
         electronWindow.loadURL(url);
 
-        return this.wrapWindow(electronWindow);
+        const newWindow = this.wrapWindow(electronWindow);
+        this.emit("window-created", { sender: this, name: "window-created", window: newWindow });
+        return newWindow;
     }
 
     public showNotification(title: string, options?: NotificationOptions) {

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -325,7 +325,9 @@ export class OpenFinContainer extends WebContainerBase {
             newOptions.name = Guid.newGuid();
         }
 
-        return this.wrapWindow(new this.desktop.Window(newOptions));
+        const newWindow = this.wrapWindow(new this.desktop.Window(newOptions));
+        this.emit("window-created", { sender: this, name: "window-created", window: newWindow });
+        return newWindow;
     }
 
     public showNotification(title: string, options?: NotificationOptions) {

--- a/src/events.ts
+++ b/src/events.ts
@@ -1,11 +1,11 @@
 export class EventArgs {
     public readonly sender: any;
 
-    public readonly innerEvent: any;
+    public readonly innerEvent?: any;
 
     public readonly name: string;
 
-    constructor(sender: any, name: string, innerEvent: any) {
+    constructor(sender: any, name: string, innerEvent?: any) {
         this.sender = sender;
         this.name = name;
         this.innerEvent = innerEvent;

--- a/tests/unit/Default/default.spec.ts
+++ b/tests/unit/Default/default.spec.ts
@@ -173,6 +173,11 @@ describe("DefaultContainer", () => {
             newWin.listener("unload", {});
             expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeUndefined();
         });
+
+        it("createWindow fires window-created", (done) => {
+            container.addListener("window-created", () => done());
+            container.createWindow("url");
+        });
     });
 
     it("getMainWindow returns DefaultContainerWindow wrapping scoped window", () => {

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -230,6 +230,11 @@ describe("ElectronContainer", () => {
         expect((<any>container).browserWindow).toHaveBeenCalledWith({ x: "x", skipTaskbar: true });
     });
 
+    it("createWindow fires window-created", (done) => {
+        container.addListener("window-created", () => done());
+        container.createWindow("url");
+    });
+
     it("addTrayIcon", () => {
         spyOn<any>(container, "tray").and.callThrough();
         container.addTrayIcon({ text: "text", icon: "icon" }, () => { }, [{ id: "id", label: "label", click: () => { } }]);

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -303,6 +303,11 @@ describe("OpenFinContainer", () => {
             );
         });
 
+        it("createWindow fires window-created", (done) => {
+            container.addListener("window-created", () => done());
+            container.createWindow("url");
+        });
+
         describe("window management", () => {
             it("getAllWindows returns wrapped native windows", (done) => {
                 container.getAllWindows().then(windows => {

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -80,8 +80,25 @@ describe("container", () => {
                 });
             });
 
+            it("loadLayout firews layout-loaded", (done) => {
+                container.addListener("layout-loaded", (e) => {
+                    done();
+                });
+                
+                container.loadLayout("Test");
+            });
+
             it("saveLayoutToStorage", () => {
                 const layout: PersistedWindowLayout = new PersistedWindowLayout();
+                container.saveLayoutToStorage("Test", layout);
+            });
+
+            it("saveLayoutToStorage fires layout-saved", (done) => {
+                const layout: PersistedWindowLayout = new PersistedWindowLayout();
+                container.addListener("layout-saved", (e) => {
+                    expect((<any>e).layout).toEqual(layout);
+                    done();
+                });
                 container.saveLayoutToStorage("Test", layout);
             });
 
@@ -90,6 +107,20 @@ describe("container", () => {
                     expect(layouts).toBeDefined();
                     done();
                 });
+            });
+        });
+
+        describe("instance events", () => {
+            it("addListener", done => {
+                container.addListener("window-created", e => done());
+                container.emit("window-created", { sender: this, name: "window-created" });
+            });
+
+            it("removeListener", () => {
+                const callback = e => fail();
+                container.addListener("window-created", callback);
+                container.removeListener("window-created", callback);
+                container.emit("window-created", { sender: this, name: "window-created" });
             });
         });
     });

--- a/tests/unit/events.spec.ts
+++ b/tests/unit/events.spec.ts
@@ -43,8 +43,8 @@ describe("EventEmitter", () => {
             expect(event).toEqual(args);
             done();
         };
-        emitter.addListener(args.type, callback);
-        emitter.emit(args.type, args);
+        emitter.addListener(args.name, callback);
+        emitter.emit(args.name, args);
     });
 
     it("registerAndWrapListener", (done) => {


### PR DESCRIPTION
- Extend EventEmitter
- Add window-created, layout-saved, layout-loaded events
- Overide addListener, removeListener and emit to provide custom union type event args