### PR TITLE
Add support for static events

### DIFF
--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -43,9 +43,13 @@ desktopJS.Electron.ElectronContainer.prototype.showNotification = function (titl
 document.addEventListener("DOMContentLoaded", function (event) {
 	hostName.innerHTML = container.hostType + "<br />" + container.uuid;
 
-	container.addListener("window-created", (e) => console.log("Window created"));
+	container.addListener("window-created", (e) => console.log("Window created: " + e.window + ", " + e.windowId + ", " + e.windowName));
 	container.addListener("layout-loaded", (e) => console.log("Layout loaded"));
 	container.addListener("layout-saved", (e) => console.log("Layout saved"));
+
+	desktopJS.Container.addListener("window-created", (e) => console.log("Window created - static: " + e.windowId + ", " + e.windowName));
+	desktopJS.Container.addListener("layout-saved", (e) => console.log("Layout saved - static: " + e.layoutName));
+	desktopJS.Container.addListener("layout-loaded", (e) => console.log("Layout loaded - static: " + e.layoutName));
 
 	subscribe();
 });

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -1,6 +1,6 @@
 import * as ContainerRegistry from "../registry";
 import { ContainerWindow, PersistedWindowLayout, PersistedWindow, Rectangle } from "../window";
-import { WebContainerBase } from "../container";
+import { Container, WebContainerBase } from "../container";
 import { ObjectTransform, PropertyMap } from "../propertymapping";
 import { NotificationOptions, ContainerNotification } from "../notification";
 import { TrayIconDetails } from "../tray";
@@ -326,7 +326,8 @@ export class OpenFinContainer extends WebContainerBase {
         }
 
         const newWindow = this.wrapWindow(new this.desktop.Window(newOptions));
-        this.emit("window-created", { sender: this, name: "window-created", window: newWindow });
+        this.emit("window-created", { sender: this, name: "window-created", window: newWindow, windowId: newOptions.name, windowName: newOptions.name });
+        Container.emit("window-created", { name: "window-created", windowId: newOptions.name, windowName: newOptions.name });
         return newWindow;
     }
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -12,11 +12,14 @@ export type ContainerEventType =
     "layout-saved";
 
 export class WindowEventArgs extends EventArgs {
-    public readonly window: ContainerWindow;
+    public readonly window?: ContainerWindow;
+    public readonly windowId: string;
+    public readonly windowName?: string;
 }
 
 export class LayoutEventArgs extends EventArgs {
-    public readonly layout: PersistedWindowLayout;
+    public readonly layout?: PersistedWindowLayout;
+    public readonly layoutName: string;
 }
 
 export type ContainerEventArgs = EventArgs | WindowEventArgs | LayoutEventArgs;
@@ -26,18 +29,34 @@ export type ContainerEventArgs = EventArgs | WindowEventArgs | LayoutEventArgs;
  * @extends ContainerWindowManager
  * @extends ContainerNotificationManager
  */
-export interface Container extends ContainerWindowManager, ContainerNotificationManager {
+export abstract class Container extends EventEmitter implements ContainerWindowManager, ContainerNotificationManager {
+    private static _ipc: MessageBus; // tslint:disable-line
+
     /**
      * Display type of current Container.
      * @type {string}
      */
-    hostType: string;
+    public abstract hostType: string;
 
     /**
      * Unique v4 GUID for this Container instance
      * @type {string}
      */
-    uuid: string;
+    public abstract uuid: string;
+
+    private static staticEmitter: EventEmitter = new EventEmitter();
+
+    public abstract getMainWindow(): ContainerWindow;
+
+    public abstract getCurrentWindow(): ContainerWindow;
+
+    public abstract createWindow(url: string, options?: any): ContainerWindow;
+
+    public abstract saveLayout(name: string): Promise<PersistedWindowLayout>;
+
+    public abstract loadLayout(name: string): Promise<PersistedWindowLayout>;
+
+    public abstract getLayouts(): Promise<PersistedWindowLayout[]>;
 
     /**
      * Adds an icon and context menu to the system notification area.
@@ -45,34 +64,78 @@ export interface Container extends ContainerWindowManager, ContainerNotification
      * @param listener (Optional) Callback for when the tray icon is clicked.
      * @param {MenuItem[]} menuItems (Optional) Context menu.
      */
-    addTrayIcon(details: TrayIconDetails, listener?: () => void, menuItems?: MenuItem[]);
+    public abstract addTrayIcon(details: TrayIconDetails, listener?: () => void, menuItems?: MenuItem[]);
+
+    public abstract showNotification(title: string, options?: NotificationOptions);
+
+    public abstract getAllWindows(): Promise<ContainerWindow[]>;
+
+    public static get ipc(): MessageBus {
+        return Container._ipc;
+    }
+
+    public static set ipc(value: MessageBus) {
+        Container._ipc = value;
+
+        // If a MessageBus exists for the container then redefine the static emitter to be based on that bus
+        // When a MessageBus is never defined, then the events only publish within current window
+        Container.staticEmitter = new EventEmitter(value);
+    }
 
     /**
      * A messaging bus for sending and receiving messages
      */
-    readonly ipc: MessageBus;
+    public get ipc(): MessageBus {
+        return Container.ipc;
+    }
+
+    public set ipc(value: MessageBus) {
+        Container.ipc = value;
+    }
 
     /**
      * Persistent storage
      */
-    storage: Storage;
+    public storage: Storage;
+
+    public addListener(eventName: ContainerEventType, listener: (event: ContainerEventArgs) => void): this { // tslint:disable-line
+        return super.addListener(eventName, listener);
+    }
+
+    public removeListener(eventName: ContainerEventType, listener: (event: ContainerEventArgs) => void): this { // tslint:disable-line
+        return super.removeListener(eventName, listener);
+    }
+
+    public emit(eventName: ContainerEventType, eventArgs: ContainerEventArgs) { // tslint:disable-line
+        super.emit(eventName, eventArgs);
+    }
+
+    public static addListener(eventName: ContainerEventType, listener: (event: ContainerEventArgs) => void) { // tslint:disable-line
+        if (Container.staticEmitter) { Container.staticEmitter.addListener(eventName, listener); }
+    }
+
+    public static removeListener(eventName: ContainerEventType, listener: (event: ContainerEventArgs) => void) { // tslint:disable-line
+        if (Container.staticEmitter) { Container.staticEmitter.removeListener(eventName, listener); }
+    }
+
+    public static emit(eventName: ContainerEventType, eventArgs: ContainerEventArgs) { // tslint:disable-line
+        if (Container.staticEmitter) { Container.staticEmitter.emit(eventName, eventArgs, Container.ipc); }
+    }
+
+    public static listeners(eventName: string): ((event: EventArgs) => void)[] { // tslint:disable-line
+        return Container.staticEmitter.listeners(eventName);
+    }
 }
 
 /**
  * Represents a common Container to be used as a base for any custom Container implementation.
  * @augments Container
  */
-export abstract class ContainerBase extends EventEmitter implements Container {
+export abstract class ContainerBase extends Container {
     public hostType: string;
     public uuid: string = Guid.newGuid();
 
     public static readonly layoutsPropertyKey: string = "desktopJS-layouts";
-
-    abstract getMainWindow(): ContainerWindow;
-
-    abstract getCurrentWindow(): ContainerWindow;
-
-    abstract createWindow(url: string, options?: any): ContainerWindow;
 
     showNotification(title: string, options?: NotificationOptions) {
         throw new TypeError("Notifications not supported by this container");
@@ -82,11 +145,9 @@ export abstract class ContainerBase extends EventEmitter implements Container {
         throw new TypeError("Tray icons are not supported by this container.");
     }
 
-    public ipc: MessageBus;
-
     public storage: Storage = (typeof window !== "undefined" && window)
-            ? window.localStorage
-            : undefined;
+        ? window.localStorage
+        : undefined;
 
     protected getLayoutFromStorage(name: string): PersistedWindowLayout {
         return JSON.parse(this.storage.getItem(ContainerBase.layoutsPropertyKey))[name];
@@ -102,12 +163,11 @@ export abstract class ContainerBase extends EventEmitter implements Container {
         layouts[name] = layout;
 
         this.storage.setItem(ContainerBase.layoutsPropertyKey, JSON.stringify(layouts));
-        this.emit("layout-saved", { sender: this, name: "layout-loaded", layout: layout });
+        this.emit("layout-saved", { sender: this, name: "layout-saved", layout: layout, layoutName: layout.name });
+        Container.emit("layout-saved", { name: "layout-saved", layout: layout, layoutName: layout.name });
     }
 
     protected abstract closeAllWindows(excludeSelf?: Boolean): Promise<void>;
-
-    public abstract getAllWindows(): Promise<ContainerWindow[]>;
 
     public loadLayout(name: string): Promise<PersistedWindowLayout> {
         return new Promise<PersistedWindowLayout>((resolve, reject) => {
@@ -121,13 +181,12 @@ export abstract class ContainerBase extends EventEmitter implements Container {
                     }
                 }
 
-                this.emit("layout-loaded", { sender: this, name: "layout-loaded", layout: layout });
+                this.emit("layout-loaded", { sender: this, name: "layout-loaded", layout: layout, layoutName: layout.name });
+                Container.emit("layout-loaded", { name: "layout-loaded", layout: layout, layoutName: layout.name });
                 resolve(layout);
             });
         });
     }
-
-    abstract saveLayout(name: string): Promise<PersistedWindowLayout>;
 
     public getLayouts(): Promise<PersistedWindowLayout[]> {
         return new Promise<PersistedWindowLayout[]>((resolve, reject) => {
@@ -139,18 +198,6 @@ export abstract class ContainerBase extends EventEmitter implements Container {
 
             resolve(undefined);
         });
-    }
-
-    public addListener(eventName: ContainerEventType, listener: (event: ContainerEventArgs) => void): this { // tslint:disable-line
-        return super.addListener(eventName, listener);
-    }
-
-    public removeListener(eventName: ContainerEventType, listener: (event: ContainerEventArgs) => void): this { // tslint:disable-line
-        return super.removeListener(eventName, listener);
-    }
-
-    public emit(eventName: ContainerEventType, eventArgs: ContainerEventArgs) { // tslint:disable-line
-        super.emit(eventName, eventArgs);
     }
 }
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1,10 +1,11 @@
 import { resolveContainer, registerContainer, ContainerRegistration, container } from "./registry";
-import * as Container from "./container";
+import { Container } from "./container";
 import * as Default from "./Default/default";
 import * as Electron from "./Electron/electron";
 import * as OpenFin from "./OpenFin/openfin";
 
 const exportDesktopJS = {
+    Container,
     container,
     registerContainer,
     resolveContainer,

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -12,7 +12,7 @@ class MockDesktop {
 
     Window: any = MockWindow;
     Notification(): any { return {}; }
-    InterApplicationBus(): any { return new MockInterApplicationBus(); }
+    InterApplicationBus: any = new MockInterApplicationBus();
     Application: any = {
         getCurrent() {
             return MockDesktop.application;

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -1,8 +1,29 @@
-import { ContainerBase, WebContainerBase } from "../../src/container";
+import { Container, ContainerBase, WebContainerBase } from "../../src/container";
 import { ContainerWindow, PersistedWindowLayout, PersistedWindow } from "../../src/window";
 import { NotificationOptions } from "../../src/notification";
+import { MessageBus, MessageBusSubscription, MessageBusOptions } from "../../src/ipc";
+import { EventArgs } from "../../src/events";
 
 class MockContainer extends ContainerBase {
+}
+
+class MockMessageBus implements MessageBus {
+    private listener: any;
+
+    subscribe<T>(topic: string, listener: (event: any, message: T) => void, options?: MessageBusOptions): Promise<MessageBusSubscription> {
+        this.listener = listener;
+        return Promise.resolve(undefined);
+    }
+
+    unsubscribe(subscription: MessageBusSubscription): Promise<void> {
+        this.listener = undefined;
+        return Promise.resolve();
+    }
+
+    publish<T>(topic: string, message: T, options?: MessageBusOptions): Promise<void> {
+        this.listener({ topic: topic }, message);
+        return Promise.resolve();
+    }
 }
 
 class TestContainer extends ContainerBase {
@@ -16,6 +37,8 @@ class TestContainer extends ContainerBase {
 
     constructor() {
         super();
+
+        this.ipc = new MockMessageBus();
 
         this.storage = <any> {
             getItem(key: string): string {
@@ -48,7 +71,35 @@ describe("container", () => {
     let container: TestContainer;
 
     beforeEach(() => {
-        container = new TestContainer();;
+        container = new TestContainer();
+    });
+
+    it("ipc is defined", () => {
+        expect(container.ipc).toBeDefined();
+    });
+
+    describe("Static events", () => {
+        it("addListener adds callback to listeners", () => {
+            expect(Container.listeners("TestEvent").length).toEqual(0);
+            Container.addListener("TestEvent", (event: EventArgs) => { });
+            expect(Container.listeners("TestEvent").length).toEqual(1);
+        });
+
+        it("removeListener removes callback to listeners", () => {
+            expect(Container.listeners("TestEvent").length).toEqual(0);
+            const callback = (event: EventArgs) => { };
+            Container.addListener("TestEvent", callback);
+            expect(Container.listeners("TestEvent").length).toEqual(1);
+            Container.removeListener("TestEvent", callback);
+            expect(Container.listeners("TestEvent").length).toEqual(0);
+        });
+
+        it("emit invokes ipc publish", () => {
+            const args = new EventArgs(undefined, "TestEvent", {});
+            spyOn(container.ipc, "publish").and.callThrough();
+            Container.emit(args.name, args);
+            expect(container.ipc.publish).toHaveBeenCalledWith("desktopJS.static-event", { eventName: args.name, eventArgs: args });
+        });
     });
 
     describe("ContainerBase", () => {

--- a/tslint.json
+++ b/tslint.json
@@ -127,7 +127,7 @@
         ],
         "jsdoc-format": true,
         "max-classes-per-file": [  // we generally recommend making one public class per file 
-            true,
+            false,
             4
         ],
         "max-file-line-count": [


### PR DESCRIPTION
Propagating of emitted events over ipc/MessageBus to other windows in the container (or to main process in Electron).

app.js:
- Update example application to add simple static event subscriptions with logging

default.ts:
- Add some conditional checks brought on by some difficulty with unit test mocking.
- Emit "window-created" static event when creating a new window.

electron.ts:
- Add some conditional checks brought on by some difficulty with unit test mocking.
- When  testing the event args of the window-created event it was noticed that the widow name was incorrectly the url which had been changed in OpenFin a while back but not changed for Electron.
- Emit "window-created" static event when creating a new window.

openfin.ts:
- Emit "window-created" static event when creating a new window.

container.ts:
- Change Container interface to abstract class.  Move most abstract members declarations from ContainerBase up to Container.  Maintain two classes so that Container is contract and Container is a useful base implementation but not necessary.
- When ipc is set by concrete container use this to create the ipc wrapped static EventEmitter on Container.  If it is never set it uses a default EventEmitter which skips messagebus.
- Add static addListener/removeListener/emit

desktop.ts:
- Expose Container class as an export for access to static events

events.ts:
- Enhance existing EventEmitter to add support for subscribing and publishing to MessageBus to broadcast static events across windows.

tslint.json:
- Disabled arbitrary starter class per file restriction