### PR TITLE
Configure travis for publishing to npm on source tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,16 @@ cache:
     - node_modules
 
 deploy:
-  provider: pages
-  skip_cleanup: true
-  local_dir: docs/
-  github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
-  on:
-    branch: master
+  - provider: pages
+    skip_cleanup: true
+    local_dir: docs/
+    github_token: $GITHUB_TOKEN # Set in travis-ci.org dashboard
+    on:
+      branch: master
+  - provider: npm
+    skip_cleanup: true
+    email: "Brian.Ingenito@morganstanley.com"
+    api_key: $NPMJS_TOKEN # Set in travis-ci.org dashboard
+    on:
+      tags: true
+      branch: master

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "title": "desktopJS",
   "description": "Library for abstracting common container hosting",
   "version": "1.0.0",
+  "publishConfig":{
+    "access": "public"
+  },
   "main": "dist/desktop.js",
   "types": "dist/desktopjs.d.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
.travis.yml:
- Configure npm publish from my own email/authtoken.  Will revisit on whether we want this from a single shared account but concerned about securing for now as that will intrinsically mean sharing of a key with n devs.

package.json:
- publish to orgs is private by default.  Change default so that npm publish from travis to @morgan-stanley scope will work.

Fixes #61 