### PR TITLE
Add ContainerWindow static event framework

### DIFF
--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -47,7 +47,8 @@ document.addEventListener("DOMContentLoaded", function (event) {
 	container.addListener("layout-loaded", (e) => console.log("Layout loaded"));
 	container.addListener("layout-saved", (e) => console.log("Layout saved"));
 
-	desktopJS.Container.addListener("window-created", (e) => console.log("Window created - static: " + e.windowId + ", " + e.windowName));
+	desktopJS.Container.addListener("window-created", (e) => console.log("Window created - static (Container): " + e.windowId + ", " + e.windowName));
+	desktopJS.ContainerWindow.addListener("window-created", (e) => console.log("Window created - static (ContainerWindow): " + e.windowId + ", " + e.windowName));
 	desktopJS.Container.addListener("layout-saved", (e) => console.log("Layout saved - static: " + e.layoutName));
 	desktopJS.Container.addListener("layout-loaded", (e) => console.log("Layout loaded - static: " + e.layoutName));
 

--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -227,6 +227,7 @@ export class DefaultContainer extends WebContainerBase {
         const newWindow = this.wrapWindow(window);
         this.emit("window-created", { sender: this, name: "window-created", window: newWindow, windowId: uuid, windowName: newOptions.name });
         Container.emit("window-created", { name: "window-created", windowId: uuid, windowName: newOptions.name });
+        ContainerWindow.emit("window-created", { name: "window-created", windowId: uuid, windowName: newOptions.name });
         return newWindow;
     }
 

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -265,6 +265,7 @@ export class ElectronContainer extends WebContainerBase {
         const newWindow = this.wrapWindow(electronWindow);
         this.emit("window-created", { sender: this, name: "window-created", window: newWindow, windowId: electronWindow.id, windowName: windowName });
         Container.emit("window-created", { name: "window-created", windowId: electronWindow.id, windowName: windowName });
+        ContainerWindow.emit("window-created", { name: "window-created", windowId: electronWindow.id, windowName: windowName });
         return newWindow;
     }
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -328,6 +328,7 @@ export class OpenFinContainer extends WebContainerBase {
         const newWindow = this.wrapWindow(new this.desktop.Window(newOptions));
         this.emit("window-created", { sender: this, name: "window-created", window: newWindow, windowId: newOptions.name, windowName: newOptions.name });
         Container.emit("window-created", { name: "window-created", windowId: newOptions.name, windowName: newOptions.name });
+        ContainerWindow.emit("window-created", { name: "window-created", windowId: newOptions.name, windowName: newOptions.name });
         return newWindow;
     }
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1,11 +1,13 @@
 import { resolveContainer, registerContainer, ContainerRegistration, container } from "./registry";
 import { Container } from "./container";
+import { ContainerWindow } from "./window";
 import * as Default from "./Default/default";
 import * as Electron from "./Electron/electron";
 import * as OpenFin from "./OpenFin/openfin";
 
 const exportDesktopJS = {
     Container,
+    ContainerWindow,
     container,
     registerContainer,
     resolveContainer,

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -2,12 +2,12 @@ import { Container, ContainerBase, WebContainerBase } from "../../src/container"
 import { ContainerWindow, PersistedWindowLayout, PersistedWindow } from "../../src/window";
 import { NotificationOptions } from "../../src/notification";
 import { MessageBus, MessageBusSubscription, MessageBusOptions } from "../../src/ipc";
-import { EventArgs } from "../../src/events";
+import { EventArgs, EventEmitter } from "../../src/events";
 
 class MockContainer extends ContainerBase {
 }
 
-class MockMessageBus implements MessageBus {
+export class MockMessageBus implements MessageBus { // tslint:disable-line
     private listener: any;
 
     subscribe<T>(topic: string, listener: (event: any, message: T) => void, options?: MessageBusOptions): Promise<MessageBusSubscription> {
@@ -26,7 +26,7 @@ class MockMessageBus implements MessageBus {
     }
 }
 
-class TestContainer extends ContainerBase {
+export class TestContainer extends ContainerBase {
     getMainWindow(): ContainerWindow {
         return undefined;
     }
@@ -72,6 +72,7 @@ describe("container", () => {
 
     beforeEach(() => {
         container = new TestContainer();
+        (<any>EventEmitter).staticEventListeners = new Map();
     });
 
     it("ipc is defined", () => {
@@ -98,7 +99,7 @@ describe("container", () => {
             const args = new EventArgs(undefined, "TestEvent", {});
             spyOn(container.ipc, "publish").and.callThrough();
             Container.emit(args.name, args);
-            expect(container.ipc.publish).toHaveBeenCalledWith("desktopJS.static-event", { eventName: args.name, eventArgs: args });
+            expect(container.ipc.publish).toHaveBeenCalledWith("desktopJS.static-event", { eventName: "container-" + args.name, eventArgs: args });
         });
     });
 

--- a/tests/unit/events.spec.ts
+++ b/tests/unit/events.spec.ts
@@ -47,6 +47,16 @@ describe("EventEmitter", () => {
         emitter.emit(args.name, args);
     });
 
+    it("static emit invokes callbacks", (done) => {
+        const args = new EventArgs(undefined, "TestEvent", {});
+        const callback = (event: EventArgs) => {
+            expect(event).toEqual(args);
+            done();
+        };
+        EventEmitter.addListener(args.name, callback);
+        EventEmitter.emit(args.name, args);
+    });
+
     it("registerAndWrapListener", (done) => {
         const listener = (event: EventArgs) => { done(); };
         const wrappedCallback = emitter.registerAndWrapListener("TestEvent", listener);

--- a/tests/unit/window.spec.ts
+++ b/tests/unit/window.spec.ts
@@ -1,0 +1,35 @@
+import { Container } from "../../src/container";
+import { ContainerWindow, WindowEventType, WindowEventArgs } from "../../src/window";
+import { EventArgs, EventEmitter } from "../../src/events";
+import { TestContainer, MockMessageBus } from "./container.spec";
+
+describe ("static events", () => {
+    let container: TestContainer;
+
+    beforeEach(() => {
+        container = new TestContainer();
+        (<any>EventEmitter).staticEventListeners = new Map();
+    });
+
+    it("addListener adds callback to listeners", () => {
+        expect(ContainerWindow.listeners("window-created").length).toEqual(0);
+        ContainerWindow.addListener("window-created", (event: EventArgs) => { /* empty */ });
+        expect(ContainerWindow.listeners("window-created").length).toEqual(1);
+    });
+
+    it("removeListener removes callback to listeners", () => {
+        expect(ContainerWindow.listeners("window-created").length).toEqual(0);
+        const callback = (event: EventArgs) => { /* empty */ };
+        ContainerWindow.addListener("window-created", callback);
+        expect(ContainerWindow.listeners("window-created").length).toEqual(1);
+        ContainerWindow.removeListener("window-created", callback);
+        expect(ContainerWindow.listeners("window-created").length).toEqual(0);
+    });
+
+    it("emit invokes ipc publish", () => {
+        const args = new EventArgs(undefined, "window-created", {});
+        spyOn(container.ipc, "publish").and.callThrough();
+        ContainerWindow.emit(<WindowEventType> args.name, <WindowEventArgs> args);
+        expect(container.ipc.publish).toHaveBeenCalledWith("desktopJS.static-event", { eventName: "containerwindow-" + args.name, eventArgs: args });
+    });
+});


### PR DESCRIPTION
Events are passed via ipc/messagebus to other windows so events are emitted in each renderer as though they are local.

container.ts:
- Refactor move WindowEventArgs to window.ts
- Simplify static events in Container by updating EventEmitter to have the static implementation rather than use a private instance of EventEmitter within Container.

desktop.ts:
- Add ContainerWindow class on default export

events.ts:
- Implement static events on EventEmitter itself.  All static events will be centrally maintained here.

window.ts:
- Add decorator static event members (add, remove, emit, listeners)