### PR TITLE
Remove confusing "container" global export.

### DIFF
--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -1,4 +1,4 @@
-import { resolveContainer, registerContainer, ContainerRegistration, container } from "./registry";
+import { resolveContainer, registerContainer, ContainerRegistration } from "./registry";
 import { Container } from "./container";
 import { ContainerWindow } from "./window";
 import * as Default from "./Default/default";
@@ -8,7 +8,6 @@ import * as OpenFin from "./OpenFin/openfin";
 const exportDesktopJS = {
     Container,
     ContainerWindow,
-    container,
     registerContainer,
     resolveContainer,
     Default,


### PR DESCRIPTION
The singleton can always be retrieved via resolveContainer().

Fixes #59