### PR TITLE
Fix spacing in package.json and ignore package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 .rpt2_cache/
 build/
 docs/
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "title": "desktopJS",
   "description": "Library for abstracting common container hosting",
   "version": "1.0.0",
-  "publishConfig":{
+  "publishConfig": {
     "access": "public"
   },
   "main": "dist/desktop.js",


### PR DESCRIPTION
package.json:
- Fix missing space that npm insists on always fixing

.gitignore
- Ignore package-lock (npm ^5 and shrinkwrap) as we don't want to pin to
corporate npm registries.