### PR TITLE
Add container.getWindow(id)

### DIFF
--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -278,10 +278,24 @@ export class DefaultContainer extends WebContainerBase {
         });
     }
 
-    public getWindow(id: string): Promise<ContainerWindow | null> {
+    public getWindowById(id: string): Promise<ContainerWindow | null> {
         return new Promise<ContainerWindow>((resolve, reject) => {
             const win = this.globalWindow[DefaultContainer.windowsPropertyKey][id];
             resolve(win ? this.wrapWindow(win) : null);
+        });
+    }
+
+    public getWindowByName(name: string): Promise<ContainerWindow | null> {
+        return new Promise<ContainerWindow>((resolve, reject) => {
+            const trackedWindows = this.globalWindow[DefaultContainer.windowsPropertyKey];
+            for (const key in trackedWindows) {
+                if (trackedWindows[key][DefaultContainer.windowNamePropertyKey] === name) {
+                    resolve(this.wrapWindow(trackedWindows[key]));
+                    return;
+                }
+            }
+
+            resolve(null);
         });
     }
 

--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -19,6 +19,14 @@ export class DefaultContainerWindow extends ContainerWindow {
         super(wrap);
     }
 
+    public get id(): string {
+        return this.innerWindow[DefaultContainer.windowUuidPropertyKey];
+    }
+
+    public get name(): string {
+        return this.innerWindow[DefaultContainer.windowNamePropertyKey];
+    }
+
     public focus(): Promise<void> {
         this.innerWindow.focus();
         return Promise.resolve();
@@ -267,6 +275,13 @@ export class DefaultContainer extends WebContainerBase {
                 windows.push(trackedWindows[key]);
             }
             resolve(windows);
+        });
+    }
+
+    public getWindow(id: string): Promise<ContainerWindow | null> {
+        return new Promise<ContainerWindow>((resolve, reject) => {
+            const win = this.globalWindow[DefaultContainer.windowsPropertyKey][id];
+            resolve(win ? this.wrapWindow(win) : null);
         });
     }
 

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -312,9 +312,16 @@ export class ElectronContainer extends WebContainerBase {
         return Promise.resolve(this.browserWindow.getAllWindows().map(window => this.wrapWindow(window)));
     }
 
-    public getWindow(id: string): Promise<ContainerWindow | null> {
+    public getWindowById(id: string): Promise<ContainerWindow | null> {
         return new Promise<ContainerWindow>((resolve, reject) => {
             const win = this.browserWindow.fromId(id);
+            resolve(win ? this.wrapWindow(win) : null);
+        });
+    }
+
+    public getWindowByName(name: string): Promise<ContainerWindow | null> {
+        return new Promise<ContainerWindow>((resolve, reject) => {
+            const win = this.browserWindow.getAllWindows().find(window => window.name === name);
             resolve(win ? this.wrapWindow(win) : null);
         });
     }

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -29,6 +29,14 @@ export class ElectronContainerWindow extends ContainerWindow {
         super(wrap);
     }
 
+    public get id(): string {
+        return this.innerWindow.id;
+    }
+
+    public get name(): string {
+        return this.innerWindow.name;
+    }
+
     public focus(): Promise<void> {
         this.innerWindow.focus();
         return Promise.resolve();
@@ -302,6 +310,13 @@ export class ElectronContainer extends WebContainerBase {
 
     public getAllWindows(): Promise<ContainerWindow[]> {
         return Promise.resolve(this.browserWindow.getAllWindows().map(window => this.wrapWindow(window)));
+    }
+
+    public getWindow(id: string): Promise<ContainerWindow | null> {
+        return new Promise<ContainerWindow>((resolve, reject) => {
+            const win = this.browserWindow.fromId(id);
+            resolve(win ? this.wrapWindow(win) : null);
+        });
     }
 
     public saveLayout(name: string): Promise<PersistedWindowLayout> {

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -32,6 +32,14 @@ export class OpenFinContainerWindow extends ContainerWindow {
         super(wrap);
     }
 
+    public get id(): string {
+        return this.name;  // Reuse name since it is the unique identifier
+    }
+
+    public get name(): string {
+        return this.innerWindow.name;
+    }
+
     public focus(): Promise<void> {
         return new Promise<void>((resolve, reject) => {
             this.innerWindow.focus(resolve, reject);
@@ -447,6 +455,15 @@ export class OpenFinContainer extends WebContainerBase {
                 windows.push(this.desktop.Application.getCurrent().getWindow());
                 resolve(windows.map(window => this.wrapWindow(window)));
             }, reject);
+        });
+    }
+
+    public getWindow(id: string): Promise<ContainerWindow | null> {
+        return new Promise<ContainerWindow>((resolve, reject) => {
+            this.desktop.Application.getCurrent().getChildWindows(windows => {
+                const win = windows.find(window => window.name === id);
+                resolve(win ? this.wrapWindow(win) : null);
+            });
         });
     }
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -458,10 +458,14 @@ export class OpenFinContainer extends WebContainerBase {
         });
     }
 
-    public getWindow(id: string): Promise<ContainerWindow | null> {
+    public getWindowById(id: string): Promise<ContainerWindow | null> {
+        return this.getWindowByName(id);
+    }
+
+    public getWindowByName(name: string): Promise<ContainerWindow | null> {
         return new Promise<ContainerWindow>((resolve, reject) => {
             this.desktop.Application.getCurrent().getChildWindows(windows => {
-                const win = windows.find(window => window.name === id);
+                const win = windows.find(window => window.name === name);
                 resolve(win ? this.wrapWindow(win) : null);
             });
         });

--- a/src/container.ts
+++ b/src/container.ts
@@ -64,6 +64,8 @@ export abstract class Container extends EventEmitter implements ContainerWindowM
 
     public abstract getAllWindows(): Promise<ContainerWindow[]>;
 
+    public abstract getWindow(id: string): Promise<ContainerWindow | null>;
+
     public static get ipc(): MessageBus {
         return Container._ipc;
     }

--- a/src/container.ts
+++ b/src/container.ts
@@ -64,7 +64,9 @@ export abstract class Container extends EventEmitter implements ContainerWindowM
 
     public abstract getAllWindows(): Promise<ContainerWindow[]>;
 
-    public abstract getWindow(id: string): Promise<ContainerWindow | null>;
+    public abstract getWindowById(id: string): Promise<ContainerWindow | null>;
+
+    public abstract getWindowByName(name: string): Promise<ContainerWindow | null>;
 
     public static get ipc(): MessageBus {
         return Container._ipc;

--- a/src/window.ts
+++ b/src/window.ts
@@ -60,6 +60,10 @@ export abstract class ContainerWindow extends EventEmitter {
     /** The underlying concrete container window. */
     public readonly innerWindow: any;
 
+    public readonly id: string;
+
+    public readonly name: string;
+
     public constructor(wrap: any) {
         super();
         this.innerWindow = wrap;
@@ -159,6 +163,12 @@ export interface ContainerWindowManager {
      * @returns {Promise<ContainerWindow[]>} - A promise that returns an array of {@link ContainerWindow} if resolved
      */
     getAllWindows(): Promise<ContainerWindow[]>;
+
+    /**
+     * Retrieve a {@link ContainerWindow} with provided id.
+     * @returns {Promise<ContainerWindow>} - A promise that returns a {ContainerWindow} if resolved
+     */
+    getWindow(id: string): Promise<ContainerWindow | null>;
 
     /**
      * Creates a new ContainerWindow.

--- a/src/window.ts
+++ b/src/window.ts
@@ -168,7 +168,13 @@ export interface ContainerWindowManager {
      * Retrieve a {@link ContainerWindow} with provided id.
      * @returns {Promise<ContainerWindow>} - A promise that returns a {ContainerWindow} if resolved
      */
-    getWindow(id: string): Promise<ContainerWindow | null>;
+    getWindowById(id: string): Promise<ContainerWindow | null>;
+
+    /**
+     * Retrieve a {@link ContainerWindow} with provided name.
+     * @returns {Promise<ContainerWindow>} - A promise that returns a {ContainerWindow} if resolved
+     */
+    getWindowByName(name: string): Promise<ContainerWindow | null>;
 
     /**
      * Creates a new ContainerWindow.

--- a/tests/unit/Default/default.spec.ts
+++ b/tests/unit/Default/default.spec.ts
@@ -36,6 +36,16 @@ describe("DefaultContainerWindow", () => {
         });
     });
 
+    it ("id returns underlying id", () => {
+        mockWindow[DefaultContainer.windowUuidPropertyKey] = "UUID";
+        expect(win.id).toEqual("UUID");
+    });
+
+    it ("name returns underlying name", () => {
+        mockWindow[DefaultContainer.windowNamePropertyKey] = "NAME";
+        expect(win.name).toEqual("NAME");
+    });
+
     it("show throws no errors", () => {
         expect(win.show()).toBeDefined();
     });
@@ -135,7 +145,7 @@ describe("DefaultContainer", () => {
 
         beforeEach(() => {
             window = new MockWindow();
-            container = new DefaultContainer(window)
+            container = new DefaultContainer(window);
         });
 
         it("Returns a DefaultContainerWindow and invokes underlying window.open", () => {
@@ -195,7 +205,6 @@ describe("DefaultContainer", () => {
         expect(win.innerWindow).toEqual(window);
     });
 
-
     describe("Notifications", () => {
         it("showNotification warns about not being implemented", () => {
             let container: DefaultContainer = new DefaultContainer(window);
@@ -230,6 +239,35 @@ describe("DefaultContainer", () => {
                 expect(wins).not.toBeNull();
                 expect(wins.length).toEqual(2);
                 done();
+            });
+        });
+
+        describe("getWindow", () => {
+            let container: DefaultContainer;
+
+            beforeEach(() => {
+                container = new DefaultContainer(window);
+            });
+
+            it("getWindow returns wrapped window", (done) => {
+                window[DefaultContainer.windowsPropertyKey] = {
+                    "1": new MockWindow(),
+                    "2": new MockWindow(),
+                    "3": new MockWindow()
+                };
+
+                container.getWindow("1").then(win => {
+                    expect(win).toBeDefined();
+                    expect(win.innerWindow).toEqual(window[DefaultContainer.windowsPropertyKey]["1"]);
+                    done();
+                });
+            });
+
+            it ("getWindow with unknown id returns null", (done) => {
+                container.getWindow("DoesNotExist").then(win => {
+                    expect(win).toBeNull();
+                    done();
+                });
             });
         });
 

--- a/tests/unit/Default/default.spec.ts
+++ b/tests/unit/Default/default.spec.ts
@@ -249,22 +249,45 @@ describe("DefaultContainer", () => {
                 container = new DefaultContainer(window);
             });
 
-            it("getWindow returns wrapped window", (done) => {
+            it("getWindowById returns wrapped window", (done) => {
                 window[DefaultContainer.windowsPropertyKey] = {
                     "1": new MockWindow(),
                     "2": new MockWindow(),
                     "3": new MockWindow()
                 };
 
-                container.getWindow("1").then(win => {
+                container.getWindowById("1").then(win => {
                     expect(win).toBeDefined();
                     expect(win.innerWindow).toEqual(window[DefaultContainer.windowsPropertyKey]["1"]);
                     done();
                 });
             });
 
-            it ("getWindow with unknown id returns null", (done) => {
-                container.getWindow("DoesNotExist").then(win => {
+            it ("getWindowById with unknown id returns null", (done) => {
+                container.getWindowById("DoesNotExist").then(win => {
+                    expect(win).toBeNull();
+                    done();
+                });
+            });
+
+            it("getWindowByName returns wrapped window", (done) => {
+                window[DefaultContainer.windowsPropertyKey] = {
+                    "1": new MockWindow(),
+                    "2": new MockWindow(),
+                    "3": new MockWindow()
+                };
+
+                window[DefaultContainer.windowsPropertyKey]["1"][DefaultContainer.windowNamePropertyKey] = "Name";
+
+                container.getWindowByName("Name").then(win => {
+                    expect(win).toBeDefined();
+                    expect(win.innerWindow).toEqual(window[DefaultContainer.windowsPropertyKey]["1"]);
+                    done();
+                });
+            });
+
+            it ("getWindowByName with unknown name returns null", (done) => {
+                container.getWindowByName("DoesNotExist").then(win => {
                     expect(win).toBeNull();
                     done();
                 });

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -172,7 +172,7 @@ describe("ElectronContainer", () => {
     let electron: any;
     let container: ElectronContainer;
     let globalWindow: any = {};
-    let windows: MockWindow[] = [new MockWindow(), new MockWindow()];
+    let windows: MockWindow[] = [new MockWindow(), new MockWindow("Name")];
 
     beforeEach(() => {
         electron = {
@@ -289,17 +289,31 @@ describe("ElectronContainer", () => {
         });
 
         describe("getWindow", () => {
-            it("getWindow returns wrapped window", (done) => {
+            it("getWindowById returns wrapped window", (done) => {
                 spyOn(electron.BrowserWindow, "fromId").and.returnValue(new MockWindow());
-                container.getWindow("1").then(win => {
+                container.getWindowById("1").then(win => {
                     expect(electron.BrowserWindow.fromId).toHaveBeenCalledWith("1");
                     expect(win).toBeDefined();
                     done();
                 });
             });
 
-            it ("getWindow with unknown id returns null", (done) => {
-                container.getWindow("DoesNotExist").then(win => {
+            it ("getWindowById with unknown id returns null", (done) => {
+                container.getWindowById("DoesNotExist").then(win => {
+                    expect(win).toBeNull();
+                    done();
+                });
+            });
+
+            it("getWindowByName returns wrapped window", (done) => {
+                container.getWindowByName("Name").then(win => {
+                    expect(win).toBeDefined();
+                    done();
+                });
+            });
+
+            it ("getWindowByName with unknown name returns null", (done) => {
+                container.getWindowByName("DoesNotExist").then(win => {
                     expect(win).toBeNull();
                     done();
                 });

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -3,6 +3,7 @@ import { MessageBusSubscription } from "../../../src/ipc";
 
 class MockWindow {
     public name: string;
+    public id: number;
 
     constructor(name?: string) {
         this.name = name;
@@ -66,6 +67,16 @@ describe("ElectronContainerWindow", () => {
         expect(win).toBeDefined();
         expect(win.innerWindow).toBeDefined();
         expect(win.innerWindow).toEqual(innerWin);
+    });
+
+    it ("id returns underlying id", () => {
+        innerWin.id = "ID";
+        expect(win.id).toEqual("ID");
+    });
+
+    it ("name returns underlying name", () => {
+        innerWin.name = "NAME";
+        expect(win.name).toEqual("NAME");
     });
 
     describe("Window members", () => {
@@ -262,7 +273,8 @@ describe("ElectronContainer", () => {
     describe("window management", () => {
         beforeEach(() => {
             electron.BrowserWindow = {
-                getAllWindows(): MockWindow[] { return windows; }
+                getAllWindows(): MockWindow[] { return windows; },
+                fromId(): any {  };
             };
 
             container = new ElectronContainer(electron, new MockIpc());
@@ -273,6 +285,24 @@ describe("ElectronContainer", () => {
                 expect(wins).not.toBeNull();
                 expect(wins.length).toEqual(windows.length);
                 done();
+            });
+        });
+
+        describe("getWindow", () => {
+            it("getWindow returns wrapped window", (done) => {
+                spyOn(electron.BrowserWindow, "fromId").and.returnValue(new MockWindow());
+                container.getWindow("1").then(win => {
+                    expect(electron.BrowserWindow.fromId).toHaveBeenCalledWith("1");
+                    expect(win).toBeDefined();
+                    done();
+                });
+            });
+
+            it ("getWindow with unknown id returns null", (done) => {
+                container.getWindow("DoesNotExist").then(win => {
+                    expect(win).toBeNull();
+                    done();
+                });
             });
         });
 

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -335,16 +335,31 @@ describe("OpenFinContainer", () => {
             });
 
             describe("getWindow", () => {
-                it("getWindow returns wrapped window", (done) => {
-                    container.getWindow("Singleton").then(win => {
+                it("getWindowById returns wrapped window", (done) => {
+                    container.getWindowById("Singleton").then(win => {
                         expect(win).toBeDefined();
                         expect(win.id).toEqual("Singleton");
                         done();
                     });
                 });
 
-                it ("getWindow with unknown id returns null", (done) => {
-                    container.getWindow("DoesNotExist").then(win => {
+                it ("getWindowById with unknown id returns null", (done) => {
+                    container.getWindowById("DoesNotExist").then(win => {
+                        expect(win).toBeNull();
+                        done();
+                    });
+                });
+
+                it("getWindowByName returns wrapped window", (done) => {
+                    container.getWindowByName("Singleton").then(win => {
+                        expect(win).toBeDefined();
+                        expect(win.id).toEqual("Singleton");
+                        done();
+                    });
+                });
+
+                it ("getWindowByName with unknown name returns null", (done) => {
+                    container.getWindowByName("DoesNotExist").then(win => {
                         expect(win).toBeNull();
                         done();
                     });

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -44,7 +44,13 @@ class MockInterApplicationBus {
 }
 
 class MockWindow {
-    static singleton: MockWindow = new MockWindow();
+    static singleton: MockWindow = new MockWindow("Singleton");
+
+    constructor(name?: string) {
+        this.name = name;
+    }
+
+    public name: string;
 
     static getCurrent(): any { return MockWindow.singleton; }
 
@@ -105,7 +111,7 @@ describe("OpenFinContainerWindow", () => {
     let win: OpenFinContainerWindow;
 
     beforeEach(() => {
-        innerWin = new MockWindow;
+        innerWin = new MockWindow();
         win = new OpenFinContainerWindow(innerWin);
     });
 
@@ -113,6 +119,16 @@ describe("OpenFinContainerWindow", () => {
         expect(win).toBeDefined();
         expect(win.innerWindow).toBeDefined();
         expect(win.innerWindow).toEqual(innerWin);
+    });
+
+    it ("id returns underlying name", () => {
+        innerWin.name = "NAME";
+        expect(win.id).toEqual("NAME");
+    });
+
+    it ("name returns underlying name", () => {
+        innerWin.name = "NAME";
+        expect(win.name).toEqual("NAME");
     });
 
     it("focus", (done) => {
@@ -315,6 +331,23 @@ describe("OpenFinContainer", () => {
                     expect(windows.length).toEqual(2);
                     expect(windows[0].innerWindow).toEqual(MockWindow.singleton);
                     done();
+                });
+            });
+
+            describe("getWindow", () => {
+                it("getWindow returns wrapped window", (done) => {
+                    container.getWindow("Singleton").then(win => {
+                        expect(win).toBeDefined();
+                        expect(win.id).toEqual("Singleton");
+                        done();
+                    });
+                });
+
+                it ("getWindow with unknown id returns null", (done) => {
+                    container.getWindow("DoesNotExist").then(win => {
+                        expect(win).toBeNull();
+                        done();
+                    });
                 });
             });
 


### PR DESCRIPTION
- Add getWindow to ContainerWindowManager and implement in each supported concrete container
- Add decorator name/id fields for each concrete ContainerWindow.  While this isn't required for getWindow it is useful for retrieving the id of existing windows.

Fixes #56 