### PR TITLE
Change relative examples link to absolute to ensure it works when viewing the readme under npmjs and github.io.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,5 +98,5 @@ or it is recommended to define a custom keyboard binding.
 Examples
 --------
 Examples showcasing usage of desktopJS for various containers and scenarios can be found under
-the [examples](examples/README.md) directory.
+the [examples](https://github.com/Morgan-Stanley/desktopJS/tree/master/examples) directory.
 


### PR DESCRIPTION
Fixes #38