### PR TITLE
Add version property to default export (eg: desktopJS.version)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var gulp = require('gulp'),
     nodeResolve = require('rollup-plugin-node-resolve'),
     commonjs = require('rollup-plugin-commonjs'),
     tsrollup = require('rollup-plugin-typescript'),
+    rollupReplace = require('rollup-plugin-replace'),
     typescript = require('typescript'),
     pkg = require('./package.json'),
     dts = require('dts-bundle'),
@@ -56,7 +57,10 @@ function createBundle(format, destination) {
         plugins: [
             tsrollup({ typescript: typescript }),
             nodeResolve(),
-            commonjs()
+            commonjs(),
+            rollupReplace({
+                PACKAGE_VERSION: pkg.version
+            })
         ]
     }).then(function (bundle) {
         bundle.write({

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "rollup": "^0.41.6",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
+    "rollup-plugin-replace": "^2.0.0",
     "rollup-plugin-typescript": "^0.8.1",
     "tslib": "^1.6.0",
     "tslint": "^5.3.2",

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -6,6 +6,7 @@ import * as Electron from "./Electron/electron";
 import * as OpenFin from "./OpenFin/openfin";
 
 const exportDesktopJS = {
+    get version(): string { return "PACKAGE_VERSION"; },
     Container,
     ContainerWindow,
     registerContainer,

--- a/tests/unit/desktop.spec.ts
+++ b/tests/unit/desktop.spec.ts
@@ -3,5 +3,6 @@ import * as desktopJS from "../../src/desktop";
 describe("desktop", () => {
     it ("module exports", () => {
         expect(desktopJS.default.registerContainer).toBeDefined();
+        expect(desktopJS.default.version).toBeDefined();
     });
 });


### PR DESCRIPTION
Replacement is done on incoming source by rollup.  Since unit test build is currently not built by rollup we can not check for replacement in tests.

![image](https://user-images.githubusercontent.com/28159742/33485121-30abf08c-d673-11e7-97c3-d6b0702402de.png)