### PR TITLE
On ElectronMessageBus publish, if the current ipc has no send (eg: main process) then invoke the listeners directly

### DIFF
--- a/examples/electron/electron.js
+++ b/examples/electron/electron.js
@@ -7,6 +7,8 @@ let mainWindow;
 function createWindow() {
     let container = desktopJS.resolveContainer();
 
+    desktopJS.ContainerWindow.addListener("window-created", (e) => console.log("Window created - static (ContainerWindow): " + e.windowId + ", " + e.windowName));
+
     mainWindow = container.createWindow('http://localhost:8000');
  
     let trayIcon = electron.nativeImage.createFromPath(__dirname + '\\..\\web\\favicon.ico');

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -121,7 +121,7 @@ export class ElectronMessageBus implements MessageBus {
     }
 
     public publish<T>(topic: string, message: T, options?: MessageBusOptions): Promise<void> {
-        // Publish to main from renderer (send is not available on ipcMain)
+        // If publisher is targeting a window, do not send to main
         if (!options || !options.name) {
             if ((<any>this.ipc).send !== undefined) {
                 // Publish to main from renderer (send is not available on ipcMain)

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -122,10 +122,13 @@ export class ElectronMessageBus implements MessageBus {
 
     public publish<T>(topic: string, message: T, options?: MessageBusOptions): Promise<void> {
         // Publish to main from renderer (send is not available on ipcMain)
-        if ((<any>this.ipc).send !== undefined) {
-            // If publisher is targeting a window, do not send to main
-            if (!options || !options.name) {
+        if (!options || !options.name) {
+            if ((<any>this.ipc).send !== undefined) {
+                // Publish to main from renderer (send is not available on ipcMain)
                 (<any>this.ipc).send(topic, message);
+            } else {
+                // we are in main so invoke listener directly
+                this.ipc.listeners(topic).forEach(cb => cb({ topic: topic }, message));
             }
         }
 


### PR DESCRIPTION
Fixes #89