### PR TITLE
Refactor SnapAssistWindowManager move handler

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -287,6 +287,11 @@ export class SnapAssistWindowManager {
         }
     }
 
+    private moveWindow(win: ContainerWindow, bounds: Rectangle) {
+        this.snappingWindow = win.id;
+        win.setBounds(bounds).then(() => this.snappingWindow = undefined);
+    }
+
     public attach(win?: ContainerWindow) {
         if (win) {
             this.onAttached(win);
@@ -309,7 +314,7 @@ export class SnapAssistWindowManager {
 
                             // Get bounds of all other windows except those already grouped with current moving window
                             windows.filter(window => id !== window.id && !groupedWindows.find(groupedWin => groupedWin.id === window.id)).forEach(window => {
-                                promises.push(new Promise((innerResolve, innerReject) => {
+                                promises.push(new Promise(innerResolve => {
                                     window.getBounds().then(targetBounds => innerResolve(targetBounds));
                                 }));
                             });
@@ -322,15 +327,13 @@ export class SnapAssistWindowManager {
                                     snapHint = this.getSnapBounds(snapHint || bounds, targetBounds);
                                     if (snapHint) {
                                         isSnapped = true;
-                                        this.snappingWindow = id;
-                                        e.sender.setBounds(snapHint).then(() => { this.snappingWindow = undefined; });
+                                        this.moveWindow(e.sender, snapHint);
                                     }
                                 }
 
                                 // If the window wasn't moved as part of snapping, we need to manually move for OpenFin since dragging was disabled
                                 if (!isSnapped && typeof fin !== "undefined") {
-                                    this.snappingWindow = id;
-                                    e.sender.setBounds(bounds).then(() => this.snappingWindow = undefined);
+                                    this.moveWindow(e.sender, bounds);
                                 }
                             });
                         });

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -217,6 +217,7 @@ describe("ElectronContainerWindow", () => {
             container = new ElectronContainer({ BrowserWindow: { fromId(): any {  } } }, new MockMainIpc(), {});
             win = new ElectronContainerWindow(innerWin, container);
             container.windowManager = jasmine.createSpyObj("WindowManager", ["getGroup"]);
+            container.windowManager.getGroup.and.returnValue([]);
             win.getGroup();
             expect(container.windowManager.getGroup).toHaveBeenCalled();
         });

--- a/tests/unit/window.spec.ts
+++ b/tests/unit/window.spec.ts
@@ -194,6 +194,27 @@ describe("SnapAssistWindowManager", () => {
         }
     });
 
+    it ("move handler", (done) => {
+        const win = jasmine.createSpyObj("window", ["addListener", "getGroup", "getBounds", "setBounds"]);
+        Object.defineProperty(win, "id", { value: "1" });
+        let callback;
+        win.addListener.and.callFake((event, fn) => callback = fn);
+        win.getGroup.and.returnValue(Promise.resolve([]));
+        win.getBounds.and.returnValue(Promise.resolve(new Rectangle(0, 0, 50, 50)));
+        win.setBounds.and.callFake(done);
+
+        const win2 = jasmine.createSpyObj("targetWindow", ["addListener", "getBounds"]);
+        Object.defineProperty(win2, "id", { value: "2" });
+        win2.getBounds.and.returnValue(Promise.resolve(new Rectangle(52, 0, 50, 50)));
+
+        const container = jasmine.createSpyObj("container", ["getAllWindows"]);
+        container.getAllWindows.and.returnValue(Promise.resolve([ win, win2 ]));
+
+        const mgr = new SnapAssistWindowManager(container);
+        mgr.attach(win);
+        callback(new WindowEventArgs(win, "move", undefined));
+    });
+
     describe("getSnapBounds", () => {
         let mgr;
 

--- a/tests/unit/window.spec.ts
+++ b/tests/unit/window.spec.ts
@@ -126,6 +126,22 @@ describe("SnapAssistWindowManager", () => {
         expect(win.addListener).toHaveBeenCalled();
     });
 
+    it ("onAttached sets OpenFin frameless api", () => {
+        const win = new MockWindow();
+        const mgr = new SnapAssistWindowManager(null);
+        mgr.onAttached(win);
+    });
+
+    it ("moveWindow sets stateful id and invokes setBounds", () => {
+        const win = jasmine.createSpyObj("window", [ "setBounds" ]);
+        win.setBounds.and.returnValue(Promise.resolve());
+        Object.defineProperty(win, "id", { value: "5" });
+        const mgr = new SnapAssistWindowManager(null);
+        mgr.moveWindow(win, new Rectangle(0, 0, 0, 0));
+        expect(mgr.snappingWindow).toEqual("5");
+        expect(win.setBounds).toHaveBeenCalled();
+    });
+
     it ("isHorizontallyAligned", () => {
         const mgr = new SnapAssistWindowManager(null);
 


### PR DESCRIPTION
window.ts:
- For OpenFin, use frameless api and leverage disabled-frame-bounds-changing event vs bounds-changing.  Fixes #101
- When enumerating windows in which to snap against, ignore windows in which the moving window is already grouped

electron.ts:
- ElectronContainerWindow grouping functions did not work in main process.  If running in main call methods directly instead of trying to go via ipc. Fixes #102