### PR TITLE
Persist window grouping in window layouts

### DIFF
--- a/examples/electron/README.md
+++ b/examples/electron/README.md
@@ -27,7 +27,7 @@ let mainWindow;
 
 function createWindow() {
     let container = desktopJS.resolveContainer();
-    mainWindow = container.createWindow('http://localhost:8000');
+    container.createWindow('http://localhost:8000').then(win => mainWindow = win);
 }
 
 app.on("ready", createWindow);
@@ -65,7 +65,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 });
 
 btnOpenWindow.onclick = function () {
-	childWindow = container.createWindow("child.html",
+	container.createWindow("child.html",
 		{
 			resizable: true,
 			x: 10, y: 10,
@@ -74,7 +74,7 @@ btnOpenWindow.onclick = function () {
 			taskbar: true, icon: "assets/img/application.png",
 			minimizable: true, maximizable: true,
 			alwaysOnTop: false, center: false,
-		});
+		}).then(win => childWindow = win);
 };
 ```
 

--- a/examples/electron/electron.js
+++ b/examples/electron/electron.js
@@ -12,7 +12,7 @@ function createWindow() {
     
     snapAssist = new desktopJS.SnapAssistWindowManager(container);
 
-    mainWindow = container.createWindow('http://localhost:8000', { name: "desktopJS", main: true });
+    container.createWindow('http://localhost:8000', { name: "desktopJS", main: true }).then(win => mainWindow = win);
  
     let trayIcon = electron.nativeImage.createFromPath(__dirname + '\\..\\web\\favicon.ico');
     container.addTrayIcon({ icon: trayIcon, text: 'ContainerPOC' }, () => {

--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -88,7 +88,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
 });
 
 openWindowButton.onclick = function () {
-	childWindow = container.createWindow("http://localhost:8000",
+	container.createWindow("http://localhost:8000",
 		{
 			resizable: true,
 			x: 10, y: 10,
@@ -97,7 +97,7 @@ openWindowButton.onclick = function () {
 			taskbar: true,
 			minimizable: true, maximizable: true,
 			alwaysOnTop: false, center: false
-		});
+		}).then(win => childWindow = win);
 };
 
 visibilityButton.onclick = function () {

--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -195,7 +195,7 @@ export class DefaultContainer extends WebContainerBase {
         return new DefaultContainerWindow(containerWindow);
     }
 
-    public createWindow(url: string, options?: any): ContainerWindow {
+    public createWindow(url: string, options?: any): Promise<ContainerWindow> {
         let features: string;
         let target = "_blank";
 
@@ -236,7 +236,7 @@ export class DefaultContainer extends WebContainerBase {
         this.emit("window-created", { sender: this, name: "window-created", window: newWindow, windowId: uuid, windowName: newOptions.name });
         Container.emit("window-created", { name: "window-created", windowId: uuid, windowName: newOptions.name });
         ContainerWindow.emit("window-created", { name: "window-created", windowId: uuid, windowName: newOptions.name });
-        return newWindow;
+        return Promise.resolve(newWindow);
     }
 
     public showNotification(title: string, options?: NotificationOptions) {

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -301,7 +301,7 @@ export class ElectronContainer extends WebContainerBase {
         return new ElectronContainerWindow(containerWindow, this);
     }
 
-    public createWindow(url: string, options?: any): ContainerWindow {
+    public createWindow(url: string, options?: any): Promise<ContainerWindow> {
         const newOptions = this.getWindowOptions(options);
         const electronWindow: any = new this.browserWindow(newOptions);
         const windowName = newOptions.name || Guid.newGuid();
@@ -328,7 +328,7 @@ export class ElectronContainer extends WebContainerBase {
         this.emit("window-created", { sender: this, name: "window-created", window: newWindow, windowId: electronWindow.id, windowName: windowName });
         Container.emit("window-created", { name: "window-created", windowId: electronWindow.id, windowName: windowName });
         ContainerWindow.emit("window-created", { name: "window-created", windowId: electronWindow.id, windowName: windowName });
-        return newWindow;
+        return Promise.resolve(newWindow);
     }
 
     public showNotification(title: string, options?: NotificationOptions) {

--- a/src/container.ts
+++ b/src/container.ts
@@ -168,16 +168,37 @@ export abstract class ContainerBase extends Container {
             this.closeAllWindows(true).then(() => {
                 const layout = <PersistedWindowLayout>this.getLayoutFromStorage(name);
                 if (layout && layout.windows) {
+                    const promises: Promise<ContainerWindow>[] = [];
                     for (const window of layout.windows) {
                         const options: any = Object.assign({}, window.bounds);
                         options.name = window.name;
-                        this.createWindow(window.url, options);
+                        if (window.main) {
+                            this.getMainWindow().setBounds(window.bounds);
+                            promises.push(Promise.resolve(this.getMainWindow()));
+                        } else {
+                            promises.push(this.createWindow(window.url, options));
+                        }
                     }
-                }
 
-                this.emit("layout-loaded", { sender: this, name: "layout-loaded", layout: layout, layoutName: layout.name });
-                Container.emit("layout-loaded", { name: "layout-loaded", layout: layout, layoutName: layout.name });
-                resolve(layout);
+                    Promise.all(promises).then(windows => {
+                        windows.forEach(window => {
+                            const group = layout.windows.find(win => win.name === window.name).group;
+                            if (group && group.length > 0) {
+                                group.filter(id => id !== window.id).forEach(target => {
+                                    this.getWindowByName(layout.windows.find(win => win.id === target).name).then(targetWin => {
+                                        window.joinGroup(targetWin);
+                                    });
+                                });
+                            }
+                        });
+                    });
+
+                    this.emit("layout-loaded", { sender: this, name: "layout-loaded", layout: layout, layoutName: layout.name });
+                    Container.emit("layout-loaded", { name: "layout-loaded", layout: layout, layoutName: layout.name });
+                    resolve(layout);
+                } else {
+                    reject("Layout does not exist");
+                }
             });
         });
     }

--- a/src/container.ts
+++ b/src/container.ts
@@ -44,7 +44,7 @@ export abstract class Container extends EventEmitter implements ContainerWindowM
 
     public abstract getCurrentWindow(): ContainerWindow;
 
-    public abstract createWindow(url: string, options?: any): ContainerWindow;
+    public abstract createWindow(url: string, options?: any): Promise<ContainerWindow>;
 
     public abstract saveLayout(name: string): Promise<PersistedWindowLayout>;
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -237,9 +237,12 @@ export interface ContainerWindowManager {
 
 /** Represents a persisted window in a layout */
 export class PersistedWindow {
-    public name: any;
+    public name: string;
+    public id: string;
     public bounds: any;
-    public url: string;
+    public url?: string;
+    public main?: boolean;
+    public group?: string[];
 }
 
 /** Represents a persisted window layout */

--- a/src/window.ts
+++ b/src/window.ts
@@ -214,7 +214,7 @@ export interface ContainerWindowManager {
      * @param {any} options (Optional)
      * @returns {ContainerWindow} A new native container window wrapped within a generic ContainerWindow.
      */
-    createWindow(url: string, options?: any): ContainerWindow;
+    createWindow(url: string, options?: any): Promise<ContainerWindow>;
 
     /**
      * Loads a window layout from persistence

--- a/tests/unit/Default/default.spec.ts
+++ b/tests/unit/Default/default.spec.ts
@@ -195,19 +195,25 @@ describe("DefaultContainer", () => {
             expect(window.open).toHaveBeenCalledWith("url", "_blank", "left=x0,top=y0,");
         });
 
-        it("Window is addded to windows", () => {
-            let newWin: any = container.createWindow("url").innerWindow;
-            expect(newWin[DefaultContainer.windowUuidPropertyKey]).toBeDefined();
-            expect(newWin[DefaultContainer.windowsPropertyKey]).toBeDefined();
-            expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeDefined();
+        it("Window is added to windows", (done) => {
+            container.createWindow("url").then(win => {
+                const newWin = win.innerWindow;
+                expect(newWin[DefaultContainer.windowUuidPropertyKey]).toBeDefined();
+                expect(newWin[DefaultContainer.windowsPropertyKey]).toBeDefined();
+                expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeDefined();
+                done();
+            });
         });
 
-        it("Window is removed from windows on close", () => {
-            let newWin: any = container.createWindow("url").innerWindow;
-            expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeDefined();
-            newWin.listener("beforeunload", {});
-            newWin.listener("unload", {});
-            expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeUndefined();
+        it("Window is removed from windows on close", (done) => {
+            container.createWindow("url").then(win => {
+                const newWin = win.innerWindow;
+                expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeDefined();
+                newWin.listener("beforeunload", {});
+                newWin.listener("unload", {});
+                expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeUndefined();
+                done();
+            });
         });
 
         it("createWindow fires window-created", (done) => {

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -367,9 +367,9 @@ describe("ElectronContainer", () => {
         expect(win.innerWindow).toEqual(innerWin);
     });
 
-    it("createWindow", () => {
+    it("createWindow", (done) => {
         spyOn<any>(container, "browserWindow").and.callThrough();
-        container.createWindow("url", { x: "x", taskbar: false });
+        container.createWindow("url", { x: "x", taskbar: false }).then(done);
         expect((<any>container).browserWindow).toHaveBeenCalledWith({ x: "x", skipTaskbar: true });
     });
 
@@ -378,12 +378,12 @@ describe("ElectronContainer", () => {
         container.createWindow("url");
     });
 
-    it("createWindow on main process invokes ElectronWindowManager.initializeWindow", () => {
+    it("createWindow on main process invokes ElectronWindowManager.initializeWindow", (done) => {
         (<any>container).isRemote = false;
         container.windowManager = new ElectronWindowManager({}, new MockMainIpc(), { fromId(): any {}, getAllWindows(): any {} })
         spyOn(container.windowManager, "initializeWindow").and.callThrough();
         const options = { name: "name" };
-        container.createWindow("url", options);
+        container.createWindow("url", options).then(done);
         expect(container.windowManager.initializeWindow).toHaveBeenCalledWith(jasmine.any(Object), "name", options);
     });
 

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -29,6 +29,7 @@ class MockWindow extends MockEventEmitter {
     public id: number;
     public group: string;
     private bounds: any = { x: 0, y: 1, width: 2, height: 3 }
+    public innerWindow: any = {};
 
     constructor(name?: string) {
         super();
@@ -485,7 +486,14 @@ describe("ElectronContainer", () => {
         });
 
         it("saveLayout invokes underlying saveLayoutToStorage", (done) => {
+            container.browserWindow = {
+                getAllWindows(): MockWindow[] { return windows; },
+                fromId(): any { return {}; }
+            };
+
+            spyOn<any>(container.internalIpc, "sendSync").and.returnValue([ 1, 5, 2 ]);
             spyOn<any>(container, "saveLayoutToStorage").and.stub();
+            spyOn<any>(container, "getMainWindow").and.returnValue(new MockWindow());
             container.saveLayout("Test")
                 .then(layout => {
                     expect(layout).toBeDefined();
@@ -494,7 +502,7 @@ describe("ElectronContainer", () => {
                 }).catch(error => {
                     fail(error);
                     done();
-                });;
+                });
         });
     });
 });

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -324,16 +324,18 @@ describe("OpenFinContainer", () => {
             spyOn(desktop, "Window").and.callFake((options?: any, callback?: Function) => { if (callback) { callback(); } });
         });
 
-        it("defaults", () => {
-            let win: OpenFinContainerWindow = container.createWindow("url");
-            expect(win).toBeDefined();
-            expect(desktop.Window).toHaveBeenCalledWith({ autoShow: true, url: "url", name: jasmine.stringMatching(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/) }, jasmine.any(Function));
+        it("defaults", (done) => {
+            container.createWindow("url").then(win => {
+                expect(win).toBeDefined();
+                expect(desktop.Window).toHaveBeenCalledWith({ autoShow: true, url: "url", name: jasmine.stringMatching(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/) }, jasmine.any(Function), jasmine.any(Function));
+                done();
+            });
         });
 
-        it("createWindow defaults", () => {
+        it("createWindow defaults", (done) => {
             spyOn<any>(container, "ensureAbsoluteUrl").and.returnValue("absoluteIcon");
 
-            let win: OpenFinContainerWindow = container.createWindow("url",
+            container.createWindow("url",
                 {
                     x: "x",
                     y: "y",
@@ -343,25 +345,27 @@ describe("OpenFinContainer", () => {
                     center: "center",
                     icon: "icon",
                     name: "name"
+                }).then(win => {
+                    expect(win).toBeDefined();
+                    expect(desktop.Window).toHaveBeenCalledWith(
+                        {
+                            defaultLeft: "x",
+                            defaultTop: "y",
+                            defaultHeight: "height",
+                            defaultWidth: "width",
+                            showTaskbarIcon: "taskbar",
+                            defaultCentered: "center",
+                            icon: "absoluteIcon",
+                            autoShow: true,
+                            saveWindowState: false,
+                            url: "url",
+                            name: "name"
+                        },
+                        jasmine.any(Function),
+                        jasmine.any(Function)
+                    );
+                    done();
                 });
-
-            expect(win).toBeDefined();
-            expect(desktop.Window).toHaveBeenCalledWith(
-                {
-                    defaultLeft: "x",
-                    defaultTop: "y",
-                    defaultHeight: "height",
-                    defaultWidth: "width",
-                    showTaskbarIcon: "taskbar",
-                    defaultCentered: "center",
-                    icon: "absoluteIcon",
-                    autoShow: true,
-                    saveWindowState: false,
-                    url: "url",
-                    name: "name"
-                },
-                jasmine.any(Function)
-            );
         });
 
         it("createWindow fires window-created", (done) => {

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -56,6 +56,8 @@ class MockWindow {
 
     getParentWindow(): any { return MockWindow.singleton; }
 
+    getNativeWindow(): any { return jasmine.createSpyObj("window", ["location"]); }
+
     focus(callback: () => void, error: (reason) => void): any {
         callback();
         return {};
@@ -101,7 +103,10 @@ class MockWindow {
         return {};
     }
 
-    getGroup(callback: any, errorCallback: any) { }
+    getGroup(callback: any, errorCallback: any) {
+        callback([ MockWindow.singleton]);
+    }
+
     joinGroup(target: any, callback: any, errorCallback: any) { }
     leaveGroup(callback: any, errorCallback: any) { }
 

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -31,8 +31,8 @@ export class TestContainer extends ContainerBase {
         return undefined;
     }
 
-    createWindow(url: string, options?: any): ContainerWindow {
-        return undefined;
+    createWindow(url: string, options?: any): Promise<ContainerWindow> {
+        return Promise.resolve(undefined);
     }
 
     constructor() {
@@ -136,7 +136,7 @@ describe("container", () => {
                 container.addListener("layout-loaded", (e) => {
                     done();
                 });
-                
+
                 container.loadLayout("Test");
             });
 

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -28,11 +28,21 @@ export class MockMessageBus implements MessageBus { // tslint:disable-line
 
 export class TestContainer extends ContainerBase {
     getMainWindow(): ContainerWindow {
-        return undefined;
+        const win = jasmine.createSpyObj("ContainerWindow", ["setBounds"]);
+        Object.defineProperty(win, "name", { value: "1" });
+        return win;
+    }
+
+    getWindowByName(): Promise<ContainerWindow> {
+        const win = jasmine.createSpyObj("ContainerWindow", ["setBounds"]);
+        Object.defineProperty(win, "id", { value: "1" });
+        return Promise.resolve(win);
     }
 
     createWindow(url: string, options?: any): Promise<ContainerWindow> {
-        return Promise.resolve(undefined);
+        const win = jasmine.createSpyObj("ContainerWindow", ["id"]);
+        Object.defineProperty(win, "name", { value: "1" });
+        return Promise.resolve(win);
     }
 
     constructor() {
@@ -43,23 +53,15 @@ export class TestContainer extends ContainerBase {
         this.storage = <any> {
             getItem(key: string): string {
                 const layout: PersistedWindowLayout = new PersistedWindowLayout();
-                const win: PersistedWindow = new PersistedWindow();
-                win.name = "name";
-                win.url = "url";
-                layout.windows.push(win);
+                layout.windows.push({ name: "1", id: "1", url: "url", bounds: {}, group: ["1", "2"]});
+                layout.windows.push({ name: "2", id: "2", main: true, url: "url", bounds: {}, group: ["1", "2"]});
                 layout.name = "Test";
-                const layouts: any = { "Test": layout };
-                let test: string = JSON.stringify(layouts);
-                return test;
+                return JSON.stringify({ "Test": layout });
             },
             setItem(key: string, value: any) {
                 // no op
             }
         };
-    }
-
-    public saveLayoutToStorage(name: string, layout: PersistedWindowLayout) {
-        super.saveLayoutToStorage(name, layout);
     }
 
     public closeAllWindows(excludeSelf?: Boolean): Promise<void> {
@@ -127,12 +129,12 @@ describe("container", () => {
                 spyOn(container, "createWindow").and.callThrough();
                 container.loadLayout("Test").then(layout => {
                     expect(layout).toBeDefined();
-                    expect(container.createWindow).toHaveBeenCalledWith("url", { name: "name" });
+                    expect(container.createWindow).toHaveBeenCalledWith("url", { name: "1" });
                     done();
                 });
             });
 
-            it("loadLayout firews layout-loaded", (done) => {
+            it("loadLayout fires layout-loaded", (done) => {
                 container.addListener("layout-loaded", (e) => {
                     done();
                 });


### PR DESCRIPTION
Applies to OpenFin and Electron.  This is a breaking change as it requires an api change to createWindow to be promised based since OpenFin windows are not initialized upon return and many members can be a no-op if invoked.

container:
- Set bounds of main window when loading layout.
- If groups exist for a persisted window, restore after window is created.
- Change createWindow from synchronous to promise based

window:
- Add additional properties required for persisting main windowbounds and groups
- Change createWindow from synchronous to promise based

default: 
- Change createWindow from synchronous to promise based

electron, openfin:
- Add persistence of groups to layout
- Change createWindow from synchronous to promise based

openfin:
- Save current url of window in layout and not url in which window was originally opened.  Fixes #109

Fixes #105
Fixes #108

