### PR TITLE
Fix issues with persisting OpenFin layouts and groupings

### DIFF
--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -515,17 +515,19 @@ export class OpenFinContainer extends WebContainerBase {
                 windows.concat(mainWindow).forEach(window => {
                     promises.push(new Promise<void>((innerResolve, innerReject) => {
                         window.getBounds(bounds => {
-                            window.getGroup(group => {
-                                layout.windows.push(
-                                    {
-                                        name: window.name,
-                                        id: window.name,
-                                        url: window.getNativeWindow().location.toString(),
-                                        main: (mainWindow.name === window.name),
-                                        bounds: { x: bounds.left, y: bounds.top, width: bounds.width, height: bounds.height },
-                                        group: group.map(win => win.name)
-                                    });
-                                innerResolve();
+                            window.getOptions(options => {
+                                window.getGroup(group => {
+                                    layout.windows.push(
+                                        {
+                                            name: window.name,
+                                            id: window.name,
+                                            url: window.getNativeWindow() ? window.getNativeWindow().location.toString() : options.url,
+                                            main: (mainWindow.name === window.name),
+                                            bounds: { x: bounds.left, y: bounds.top, width: bounds.width, height: bounds.height },
+                                            group: group.map(win => win.name)
+                                        });
+                                    innerResolve();
+                                }, innerReject);
                             }, innerReject);
                         }, innerReject);
                     }));

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -41,7 +41,8 @@ export class TestContainer extends ContainerBase {
 
     createWindow(url: string, options?: any): Promise<ContainerWindow> {
         const win = jasmine.createSpyObj("ContainerWindow", ["id"]);
-        Object.defineProperty(win, "name", { value: "1" });
+        Object.defineProperty(win, "name", { value: options.name || "1" });
+        Object.defineProperty(win, "id", { value: options.name || "1" });
         return Promise.resolve(win);
     }
 
@@ -53,8 +54,9 @@ export class TestContainer extends ContainerBase {
         this.storage = <any> {
             getItem(key: string): string {
                 const layout: PersistedWindowLayout = new PersistedWindowLayout();
-                layout.windows.push({ name: "1", id: "1", url: "url", bounds: {}, group: ["1", "2"]});
-                layout.windows.push({ name: "2", id: "2", main: true, url: "url", bounds: {}, group: ["1", "2"]});
+                layout.windows.push({ name: "1", id: "1", url: "url", bounds: {}, group: ["1", "2", "3"]});
+                layout.windows.push({ name: "2", id: "2", main: true, url: "url", bounds: {}, group: ["1", "2", "3"]});
+                layout.windows.push({ name: "3", id: "3", url: "url", bounds: {}, group: ["1", "2", "3"]});
                 layout.name = "Test";
                 return JSON.stringify({ "Test": layout });
             },


### PR DESCRIPTION
container:ts:
- Due to async OpenFin joinGroup, first build and de-dupe window groupings before joining windows to prevent race condition on joins.  Fixes #117

openfin.ts:
- OpenFin sometimes returns null for getNativeWindow(). If this happens, fallback to url provided when opening the window.  Fixes #118