### PR TITLE
Change type of ContainerNotification.permission from string to type alias NotificationPermission

### DIFF
--- a/src/notification.ts
+++ b/src/notification.ts
@@ -16,7 +16,7 @@ export abstract class ContainerNotification {
     /**
      * A string representing the current permission to display notifications.
      */
-    static permission: string = "granted";
+    static permission: NotificationPermission = "granted";
 
     /**
      * A handler for the click event.  It is triggered each time the user clicks the notification.


### PR DESCRIPTION
NotificationPermission is defined as "default" | "denied" | "granted". This fixes dev time type check issue on callback from requestPermission.