### PR TITLE
Shim window.open to allow for container to know about the windows

### DIFF
--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -240,7 +240,7 @@ export class DefaultContainer extends WebContainerBase {
             }
         }
 
-        const window = this.globalWindow.open(url, target, features);  // Via window.open polyfill, registerWindow will still be invoked
+        const window = this.globalWindow.open(url, target, features);
 
         // Set name as a unique desktopJS name property instead of overloading window.name
         window[DefaultContainer.windowNamePropertyKey] = newOptions.name;

--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -199,6 +199,31 @@ export class DefaultContainer extends WebContainerBase {
         return new DefaultContainerWindow(containerWindow);
     }
 
+    protected onOpen(open: (url?: string, target?: string, features?: string, replace?: boolean) => Window,
+                     url?: string, target?: string, features?: string, replace?: boolean): Window {
+        const window = open(url, target, features, replace);
+
+        const windows = this.globalWindow[DefaultContainer.windowsPropertyKey];
+        const uuid = window[DefaultContainer.windowUuidPropertyKey] = Guid.newGuid();
+        windows[uuid] = window;
+
+        // Attach event handlers on window to cleanup reference on global windows object.  beforeunload -> unload to prevent
+        // unload being called on open within Chrome.
+        window.addEventListener("beforeunload", () => {
+            window.addEventListener("unload", () => {
+                delete windows[uuid];
+            });
+        });
+
+        // Propagate the global windows object to the new window
+        window[DefaultContainer.windowsPropertyKey] = windows;
+
+        Container.emit("window-created", { name: "window-created", windowId: uuid });
+        ContainerWindow.emit("window-created", { name: "window-created", windowId: uuid });
+
+        return window;
+    }
+
     public createWindow(url: string, options?: any): Promise<ContainerWindow> {
         let features: string;
         let target = "_blank";
@@ -215,31 +240,14 @@ export class DefaultContainer extends WebContainerBase {
             }
         }
 
-        const window = this.globalWindow.open(url, target, features);
+        const window = this.globalWindow.open(url, target, features);  // Via window.open polyfill, registerWindow will still be invoked
 
         // Set name as a unique desktopJS name property instead of overloading window.name
         window[DefaultContainer.windowNamePropertyKey] = newOptions.name;
 
-        // Add the new window to the global windows object
-        const windows = this.globalWindow[DefaultContainer.windowsPropertyKey];
-        const uuid = window[DefaultContainer.windowUuidPropertyKey] = Guid.newGuid();
-        windows[uuid] = window;
-
-        // Attach event handlers on window to cleanup reference on global windows object.  beforeunload -> unload to prevent
-        // unload being called on open within Chrome.
-        window.addEventListener("beforeunload", () => {
-            window.addEventListener("unload", () => {
-                delete windows[uuid];
-            });
-        });
-
-        // Propagate the global windows object to the new window
-        window[DefaultContainer.windowsPropertyKey] = windows;
-
         const newWindow = this.wrapWindow(window);
-        this.emit("window-created", { sender: this, name: "window-created", window: newWindow, windowId: uuid, windowName: newOptions.name });
-        Container.emit("window-created", { name: "window-created", windowId: uuid, windowName: newOptions.name });
-        ContainerWindow.emit("window-created", { name: "window-created", windowId: uuid, windowName: newOptions.name });
+        this.emit("window-created", { sender: this, name: "window-created", window: newWindow, windowId: newWindow.id, windowName: newOptions.name });
+
         return Promise.resolve(newWindow);
     }
 

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -44,7 +44,7 @@ export class ElectronContainerWindow extends ContainerWindow {
     }
 
     public get id(): string {
-        return this.innerWindow.id;
+        return this.innerWindow.id || this.innerWindow.guestId;
     }
 
     public get name(): string {

--- a/src/container.ts
+++ b/src/container.ts
@@ -251,7 +251,26 @@ export abstract class WebContainerBase extends ContainerBase {
         try {
             this.linkHelper = this.globalWindow.top.document.createElement("a");
         } catch (e) { /* Swallow */ }
+
+        if (this.globalWindow) {
+            const open = this.globalWindow.open;
+            this.globalWindow.open = (url?: string, target?: string, features?: string, replace?: boolean) => {
+                return this.onOpen(open, url, target, features, replace);
+            };
+        }
     }
+
+    protected onOpen(open: (url?: string, target?: string, features?: string, replace?: boolean) => Window,
+                     url?: string, target?: string, features?: string, replace?: boolean): Window {
+        const wrap = this.wrapWindow(open(url, target, features, replace));
+
+        Container.emit("window-created", { name: "window-created", windowId: wrap.id });
+        ContainerWindow.emit("window-created", { name: "window-created", windowId: wrap.id });
+
+        return wrap.innerWindow;
+    }
+
+    public abstract wrapWindow(window: any): ContainerWindow;
 
     /**
      * Returns an absolute url

--- a/tests/unit/Default/default.spec.ts
+++ b/tests/unit/Default/default.spec.ts
@@ -226,6 +226,14 @@ describe("DefaultContainer", () => {
             });
         });
 
+        it("Window from window.open is removed from windows on close", () => {
+            const newWin = window.open("url");
+            expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeDefined();
+            newWin.listener("beforeunload", {});
+            newWin.listener("unload", {});
+            expect(newWin[DefaultContainer.windowsPropertyKey][newWin[DefaultContainer.windowUuidPropertyKey]]).toBeUndefined();
+        });
+
         it("createWindow fires window-created", (done) => {
             container.addListener("window-created", () => done());
             container.createWindow("url");


### PR DESCRIPTION
container.ts:
- Default window.open shim for all containers

default.ts:
- Refactor bulk of createWindow into onOpen to share code paths for window.open and createWindow