### PR TITLE
Add support for linking windows to state changes of other windows

### DIFF
--- a/examples/electron/electron.js
+++ b/examples/electron/electron.js
@@ -10,7 +10,10 @@ function createWindow() {
 
     desktopJS.ContainerWindow.addListener("window-created", (e) => console.log("Window created - static (ContainerWindow): " + e.windowId + ", " + e.windowName));
     
-    snapAssist = new desktopJS.SnapAssistWindowManager(container);
+    snapAssist = new desktopJS.SnapAssistWindowManager(container,
+        {
+            windowStateTracking: desktopJS.WindowStateTracking.Main | desktopJS.WindowStateTracking.Group
+        });
 
     container.createWindow('http://localhost:8000', { name: "desktopJS", main: true }).then(win => mainWindow = win);
  

--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -83,7 +83,10 @@ document.addEventListener("DOMContentLoaded", function (event) {
 	$('[data-toggle="popover"]').popover();
 
 	if (container.getCurrentWindow().id === "desktopJS") {
-		snapAssist = new desktopJS.SnapAssistWindowManager(container);
+		snapAssist = new desktopJS.SnapAssistWindowManager(container,
+			{
+				windowStateTracking: desktopJS.WindowStateTracking.Main | desktopJS.WindowStateTracking.Group
+			});
 	}
 });
 

--- a/src/desktop.ts
+++ b/src/desktop.ts
@@ -2,7 +2,7 @@ import { resolveContainer, registerContainer, ContainerRegistration } from "./re
 import { Container } from "./container";
 import { ContainerNotification } from "./notification";
 import { ObjectTransform } from "./propertymapping";
-import { ContainerWindow, SnapAssistWindowManager } from "./window";
+import { ContainerWindow, WindowStateTracking, GroupWindowManager, SnapAssistWindowManager } from "./window";
 import * as Default from "./Default/default";
 import * as Electron from "./Electron/electron";
 import * as OpenFin from "./OpenFin/openfin";
@@ -18,5 +18,7 @@ export default class Desktop { //tslint:disable-line
     static get Default(): typeof Default { return Default; }
     static get Electron(): typeof Electron { return Electron; }
     static get OpenFin(): typeof OpenFin { return OpenFin; }
+    static get WindowStateTracking(): typeof WindowStateTracking { return WindowStateTracking; }
+    static get GroupWindowManager(): typeof GroupWindowManager { return GroupWindowManager; }
     static get SnapAssistWindowManager(): typeof SnapAssistWindowManager { return SnapAssistWindowManager; }
 }


### PR DESCRIPTION
Minimize and restore all windows from the main window or within window groups.

electron.js, app.js:
- Change default behavior of example to leverage the new window state tracking of main or group.

desktop.ts:
- Expose through default export the new base GroupWindowManager and the WindowStateTracking enum

window.ts:
- Add GroupWindowManager for tracking window state changes to drive state of other windows.
- Refactor SnapAssistWindowManager core window tracking to new base GroupWindowManager.