### PR TITLE
Fix failing registry tests

### DIFF
--- a/src/registry.ts
+++ b/src/registry.ts
@@ -14,7 +14,13 @@ export class ContainerRegistration {
     create: (options?: any) => Container;
 }
 
-const registeredContainers: { [id: string]: ContainerRegistration } = {};
+const registeredContainers: Map<string, ContainerRegistration> = new Map();
+
+/** Clears all container registrations. */
+export function clearRegistry() {
+    registeredContainers.clear();
+    container = undefined;
+}
 
 /** Register a container type in the registry.
  * @param {string} id Unique identifier of the container type (eg. Electron).

--- a/tests/unit/registry.spec.ts
+++ b/tests/unit/registry.spec.ts
@@ -19,14 +19,18 @@ class TestContainer extends DefaultContainer {
 
 describe("registry", () => {
     describe("resolveContainer", () => {
-        let container: Container = registry.resolveContainer();
+        afterEach(() => {
+            registry.clearRegistry();
+        });
 
         it("No matching condition resolves default", () => {
+            let container: Container = registry.resolveContainer();
             expect(container).toBeDefined();
             expect(container.hostType).toEqual("Default");
         });
 
         it("Subsequent call returns from cache", () => {
+            let container: Container = registry.resolveContainer();
             let container2: Container = registry.resolveContainer();
             expect(container2).toBeDefined();
             expect(container2).toEqual(container);


### PR DESCRIPTION
registry:
- Add clearRegistry to remove all container registrations
- Change internal list of containerRegistrations to a Map

registry.spec:
- Add teardown after each test to clear the registry so side effects of registrations from other tests can not impact subsequent tests

Fixes #146