### PR TITLE
Allow override of default behavior of registring W3C notification api with options to resolveContainer

### DIFF
--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -17,7 +17,7 @@ ContainerRegistry.registerContainer("Electron", {
             return false;
         }
     },
-    create: () => new ElectronContainer()
+    create: (options) => new ElectronContainer(null, null, null, options)
 });
 
 class InternalMessageType {
@@ -255,7 +255,7 @@ export class ElectronContainer extends WebContainerBase {
 
     public windowOptionsMap: PropertyMap = ElectronContainer.windowOptionsMap;
 
-    public constructor(electron?: any, ipc?: NodeJS.EventEmitter | any, win?: any) {
+    public constructor(electron?: any, ipc?: NodeJS.EventEmitter | any, win?: any, options?: any) {
         super(win);
         this.hostType = "Electron";
 
@@ -286,12 +286,20 @@ export class ElectronContainer extends WebContainerBase {
             console.error(e);
         }
 
-        this.registerNotificationsApi();
+        let replaceNotificationApi = ElectronContainer.replaceNotificationApi;
+        if (options && typeof options.replaceNotificationApi !== "undefined") {
+            replaceNotificationApi = options.replaceNotificationApi;
+        }
+
+        if (replaceNotificationApi) {
+            this.registerNotificationsApi();
+        }
+
         this.screen = new ElectronDisplayManager(this.electron);
     }
 
     protected registerNotificationsApi() {
-        if (ElectronContainer.replaceNotificationApi && typeof this.globalWindow !== "undefined" && this.globalWindow) {
+        if (typeof this.globalWindow !== "undefined" && this.globalWindow) {
             // Define owningContainer for closure to inner class
             const owningContainer: ElectronContainer = this; // tslint:disable-line
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -327,13 +327,21 @@ export class OpenFinContainer extends WebContainerBase {
         }
 
         this.ipc = new OpenFinMessageBus(this.desktop.InterApplicationBus, (<any>this.desktop.Application.getCurrent()).uuid);
-        this.registerNotificationsApi();
+
+        let replaceNotificationApi = OpenFinContainer.replaceNotificationApi;
+        if (options && typeof options.replaceNotificationApi !== "undefined") {
+            replaceNotificationApi = options.replaceNotificationApi;
+        }
+
+        if (replaceNotificationApi) {
+            this.registerNotificationsApi();
+        }
 
         this.screen = new OpenFinDisplayManager(this.desktop);
     }
 
     protected registerNotificationsApi() {
-        if (OpenFinContainer.replaceNotificationApi && typeof this.globalWindow !== "undefined" && this.globalWindow) {
+        if (typeof this.globalWindow !== "undefined" && this.globalWindow) {
             // Define owningContainer for closure to inner class
             const owningContainer: OpenFinContainer = this; // tslint:disable-line
 


### PR DESCRIPTION
* Add options support to factory create for ElectronContainer
* For OpenFin and Electron look for options.replaceNotificationApi on optional options to override default behavior