### PR TITLE
Propagate Electron and OpenFin application level window created events instead of emitting our own

### DIFF
--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -279,8 +279,13 @@ export class ElectronContainer extends WebContainerBase {
             this.internalIpc = ipc || ((this.isRemote) ? require("electron").ipcRenderer : this.electron.ipcMain);
             this.ipc = new ElectronMessageBus(this.internalIpc, this.browserWindow);
 
-            if (!this.isRemote) {
+            if (!this.isRemote || (options && typeof options.isRemote !== "undefined" && !options.isRemote)) {
                 this.windowManager = new ElectronWindowManager(this.app, this.internalIpc, this.browserWindow);
+
+                this.app.on("browser-window-created", (event, window) => {
+                    Container.emit("window-created", { name: "window-created", windowId: window.webContents.id });
+                    ContainerWindow.emit("window-created", { name: "window-created", windowId: window.webContents.id });
+                });
             }
         } catch (e) {
             console.error(e);
@@ -362,8 +367,6 @@ export class ElectronContainer extends WebContainerBase {
 
         const newWindow = this.wrapWindow(electronWindow);
         this.emit("window-created", { sender: this, name: "window-created", window: newWindow, windowId: electronWindow.id, windowName: windowName });
-        Container.emit("window-created", { name: "window-created", windowId: electronWindow.id, windowName: windowName });
-        ContainerWindow.emit("window-created", { name: "window-created", windowId: electronWindow.id, windowName: windowName });
         return Promise.resolve(newWindow);
     }
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -337,6 +337,12 @@ export class OpenFinContainer extends WebContainerBase {
             this.registerNotificationsApi();
         }
 
+        this.desktop.Application.getCurrent().addEventListener("window-created", (event: any) => {
+            this.emit("window-created", { sender: this, name: "window-created", windowId: event.name, windowName: event.name });
+            Container.emit("window-created", { name: "window-created", windowId: event.name, windowName: event.name });
+            ContainerWindow.emit("window-created", { name: "window-created", windowId: event.name, windowName: event.name });
+        });
+
         this.screen = new OpenFinDisplayManager(this.desktop);
     }
 
@@ -408,11 +414,7 @@ export class OpenFinContainer extends WebContainerBase {
 
         return new Promise<ContainerWindow>((resolve, reject) => {
             const ofWin = new this.desktop.Window(newOptions, win => {
-                const newWin = this.wrapWindow(ofWin);
-                this.emit("window-created", { sender: this, name: "window-created", window: newWin, windowId: newOptions.name, windowName: newOptions.name });
-                Container.emit("window-created", { name: "window-created", windowId: newOptions.name, windowName: newOptions.name });
-                ContainerWindow.emit("window-created", { name: "window-created", windowId: newOptions.name, windowName: newOptions.name });
-                resolve(newWin);
+                resolve(this.wrapWindow(ofWin));
             }, reject);
         });
     }

--- a/src/container.ts
+++ b/src/container.ts
@@ -267,12 +267,7 @@ export abstract class WebContainerBase extends ContainerBase {
     }
 
     protected onOpen(open: (...args: any[]) => Window, ...args: any[]): Window {
-        const wrap = this.wrapWindow(open.apply(this.globalWindow, args));
-
-        Container.emit("window-created", { name: "window-created", windowId: wrap.id });
-        ContainerWindow.emit("window-created", { name: "window-created", windowId: wrap.id });
-
-        return wrap.innerWindow;
+        return open.apply(this.globalWindow, args);
     }
 
     public abstract wrapWindow(window: any): ContainerWindow;

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -1,5 +1,6 @@
 import { ElectronContainer, ElectronContainerWindow, ElectronMessageBus, ElectronWindowManager } from "../../../src/Electron/electron";
 import { MessageBusSubscription } from "../../../src/ipc";
+import { ContainerWindow } from "../../../src/window";
 
 class MockEventEmitter {
     private eventListeners: Map<string, any> = new Map();
@@ -322,7 +323,7 @@ describe("ElectronContainer", () => {
         windows = [new MockWindow(), new MockWindow("Name")];
 
         electron = {
-            app: {},
+            app: new MockEventEmitter(),
             BrowserWindow: (options: any) => {
                 return {
                     loadURL: (url: string) => { },
@@ -416,6 +417,12 @@ describe("ElectronContainer", () => {
     it("createWindow fires window-created", (done) => {
         container.addListener("window-created", () => done());
         container.createWindow("url");
+    });
+
+    it ("app browser-window-created fires Container window-created", (done) => {
+        new ElectronContainer(electron, new MockMainIpc(), globalWindow, { isRemote: false });
+        ContainerWindow.addListener("window-created", () => done());
+        electron.app.emit("browser-window-created", {}, { webContents: {id: "id"}});
     });
 
     it("createWindow on main process invokes ElectronWindowManager.initializeWindow", (done) => {


### PR DESCRIPTION
In Electron we are no longer able to link a BrowserWindowProxy created via window.open to a BrowserWindow instance via guestID so instead use the app level browser-window-created event and webcontents.id to correlate to new windows.  Since OpenFin also has application events, change to make consistent across both containers.

Fixes #155