### PR TITLE
Cleanup async reject errors in tests

### DIFF
--- a/src/container.ts
+++ b/src/container.ts
@@ -200,7 +200,8 @@ export abstract class ContainerBase extends Container {
                             });
 
                             if (!found) {
-                                const group = layout.windows.find(win => win.name === window.name).group;
+                                const matchingWindow = layout.windows.find(win => win.name === window.name);
+                                const group = matchingWindow ? matchingWindow.group : undefined;
                                 if (group && group.length > 0) {
                                     groupMap.set(window, group.filter(id => id !== window.id));
                                 }

--- a/src/window.ts
+++ b/src/window.ts
@@ -328,9 +328,11 @@ export class GroupWindowManager {
         } else {
             // Attach handlers to any new windows that open
             ContainerWindow.addListener("window-created", (args) => {
-                this.container.getWindowById(args.windowId).then(window => {
-                    this.attach(window);
-                });
+                if (this.container) {
+                    this.container.getWindowById(args.windowId).then(window => {
+                        this.attach(window);
+                    });
+                }
             });
 
             // Attach handlers to any windows already open

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -390,9 +390,10 @@ describe("OpenFinContainer", () => {
             let app;
 
             beforeEach(() => {
-                desktop = jasmine.createSpyObj("desktop", ["Application"]);
+                desktop = jasmine.createSpyObj("desktop", ["Application", "InterApplicationBus"]);
                 app = jasmine.createSpyObj("application", ["getCurrent", "registerUser", "addEventListener"]);
                 Object.defineProperty(desktop, "Application", { value: app });
+                Object.defineProperty(desktop, "InterApplicationBus", { value: new MockInterApplicationBus() });
                 app.getCurrent.and.returnValue(app);
             });
 
@@ -663,11 +664,12 @@ describe("OpenFinDisplayManager", () => {
     let system;
    
     beforeEach(() => {
-        desktop = jasmine.createSpyObj("desktop", ["Application", "System"]);
+        desktop = jasmine.createSpyObj("desktop", ["Application", "System", "InterApplicationBus"]);
         app = jasmine.createSpyObj("application", ["getCurrent", "addEventListener"]);
         system = jasmine.createSpyObj("system", ["getMonitorInfo"]);
         Object.defineProperty(desktop, "Application", { value: app });
         Object.defineProperty(desktop, "System", { value: system });
+        Object.defineProperty(desktop, "InterApplicationBus", { value: new MockInterApplicationBus() });
         system.getMonitorInfo.and.callFake(callback => callback(
             {
                 primaryMonitor: {

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -34,7 +34,7 @@ export class TestContainer extends ContainerBase {
     }
 
     getWindowByName(): Promise<ContainerWindow> {
-        const win = jasmine.createSpyObj("ContainerWindow", ["setBounds"]);
+        const win = jasmine.createSpyObj("ContainerWindow", ["setBounds", "joinGroup"]);
         Object.defineProperty(win, "id", { value: "1" });
         return Promise.resolve(win);
     }
@@ -127,8 +127,11 @@ describe("container", () => {
         });
 
         describe("window management", () => {
+            beforeEach(() => {
+                spyOn(container, "createWindow").and.returnValue(jasmine.createSpyObj("window", ["joinGroup"]));
+            });
+
             it("loadLayout", (done) => {
-                spyOn(container, "createWindow").and.callThrough();
                 container.loadLayout("Test").then(layout => {
                     expect(layout).toBeDefined();
                     expect(container.createWindow).toHaveBeenCalledWith("url", { name: "1" });

--- a/tests/unit/window.spec.ts
+++ b/tests/unit/window.spec.ts
@@ -7,6 +7,9 @@ class MockWindow extends ContainerWindow {
     protected attachListener(eventName: WindowEventType, listener: (event: EventArgs) => void): void {
         return;
     }
+
+    public minimize(): Promise<void> { return Promise.resolve(); }
+    public restore(): Promise<void> { return Promise.resolve(); }
 }
 
 describe ("static events", () => {
@@ -302,7 +305,10 @@ describe("SnapAssistWindowManager", () => {
         win.addListener.and.callFake((event, fn) => callback = fn);
         win.getGroup.and.returnValue(Promise.resolve([]));
         win.getBounds.and.returnValue(Promise.resolve(new Rectangle(0, 0, 50, 50)));
-        win.setBounds.and.callFake(done);
+        win.setBounds.and.callFake(() => {
+            done();
+            return Promise.resolve();
+        });
 
         const win2 = jasmine.createSpyObj("targetWindow", ["addListener", "getBounds"]);
         Object.defineProperty(win2, "id", { value: "2" });


### PR DESCRIPTION
Many tests while passing and providing adequate coverage were logging promise rejects.