### PR TITLE
Disable test that has random coverage based on race condition

### DIFF
--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -419,7 +419,7 @@ describe("ElectronContainer", () => {
         container.createWindow("url");
     });
 
-    it ("app browser-window-created fires Container window-created", (done) => {
+    xit("app browser-window-created fires Container window-created", (done) => {
         new ElectronContainer(electron, new MockMainIpc(), globalWindow, { isRemote: false });
         ContainerWindow.addListener("window-created", () => done());
         electron.app.emit("browser-window-created", {}, { webContents: {id: "id"}});


### PR DESCRIPTION
Intermittent behavior based on parallel tests.  This will decrease coverage until rewritten and added back.