### PR TITLE
Add simple facade for logging

### DIFF
--- a/examples/electron/electron.js
+++ b/examples/electron/electron.js
@@ -8,7 +8,7 @@ let snapAssist;
 function createWindow() {
     let container = desktopJS.resolveContainer();
 
-    desktopJS.ContainerWindow.addListener("window-created", (e) => console.log("Window created - static (ContainerWindow): " + e.windowId + ", " + e.windowName));
+    desktopJS.ContainerWindow.addListener("window-created", (e) => container.log("info", "Window created - static (ContainerWindow): " + e.windowId + ", " + e.windowName));
     
     snapAssist = new desktopJS.SnapAssistWindowManager(container,
         {
@@ -29,7 +29,7 @@ function createWindow() {
     }, [{ label: "Exit", click: (menuItem) => app.quit() }]);
 
 	container.ipc.subscribe("stock.selected", function (event, message) {
-		console.log("Message received: " + message.symbol);
+		container.log("info", "Message received: " + message.symbol);
     });
 }
 

--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -64,14 +64,14 @@ document.addEventListener("DOMContentLoaded", function (event) {
 	$("#button-joingroup").prop("disabled", !container.getCurrentWindow().allowGrouping);
 	$("#button-leavegroup").prop("disabled", !container.getCurrentWindow().allowGrouping);
 
-	container.addListener("window-created", (e) => console.log("Window created: " + e.window + ", " + e.windowId + ", " + e.windowName));
-	container.addListener("layout-loaded", (e) => console.log("Layout loaded"));
-	container.addListener("layout-saved", (e) => console.log("Layout saved"));
+	container.addListener("window-created", (e) => container.log("info", "Window created: " + e.window + ", " + e.windowId + ", " + e.windowName));
+	container.addListener("layout-loaded", (e) => container.log("info", "Layout loaded"));
+	container.addListener("layout-saved", (e) => container.log("info", "Layout saved"));
 
-	desktopJS.Container.addListener("window-created", (e) => console.log("Window created - static (Container): " + e.windowId + ", " + e.windowName));
-	desktopJS.ContainerWindow.addListener("window-created", (e) => console.log("Window created - static (ContainerWindow): " + e.windowId + ", " + e.windowName));
-	desktopJS.Container.addListener("layout-saved", (e) => console.log("Layout saved - static: " + e.layoutName));
-	desktopJS.Container.addListener("layout-loaded", (e) => console.log("Layout loaded - static: " + e.layoutName));
+	desktopJS.Container.addListener("window-created", (e) => container.log("info", "Window created - static (Container): " + e.windowId + ", " + e.windowName));
+	desktopJS.ContainerWindow.addListener("window-created", (e) => container.log("info", "Window created - static (ContainerWindow): " + e.windowId + ", " + e.windowName));
+	desktopJS.Container.addListener("layout-saved", (e) => container.log("info", "Layout saved - static: " + e.layoutName));
+	desktopJS.Container.addListener("layout-loaded", (e) => container.log("info", "Layout loaded - static: " + e.layoutName));
 
 	subscribe();
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -367,6 +367,12 @@ export class OpenFinContainer extends WebContainerBase {
         }
     }
 
+    public log(level: "debug" | "info" | "warn" | "error", message: string): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            this.desktop.System.log(level, message, resolve, reject);
+        });
+    }
+
     public getMainWindow(): ContainerWindow {
         if (!this.mainWindow) {
             this.mainWindow = this.wrapWindow(this.desktop.Application.getCurrent().getWindow());

--- a/src/container.ts
+++ b/src/container.ts
@@ -238,6 +238,39 @@ export abstract class ContainerBase extends Container {
             resolve(undefined);
         });
     }
+
+    /**
+     * Write a log message
+     * @param  {"debug" | "info" | "warn" | "error"} level The log level for the entry
+     * @param {string} message The log message text
+     */
+    public log(level: "debug" | "info" | "warn" | "error", message: string): Promise<void> {
+        return new Promise<void>(resolve => {
+            let logger;
+            switch (level) {
+                case "debug": {
+                    logger = console.debug;
+                    break;
+                }
+                case "warn": {
+                    logger = console.warn;
+                    break;
+                }
+                case "error": {
+                    logger = console.error;
+                    break;
+                }
+                default: {
+                    logger = console.log;
+                }
+            }
+
+            if (logger) {
+                logger(message);
+            }
+            resolve();
+        });
+    }
 }
 
 /**

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -419,6 +419,32 @@ describe("OpenFinContainer", () => {
         });
     });
 
+    describe("log", () => {
+        beforeEach(() => {
+            Object.defineProperty(desktop, "System", { value: jasmine.createSpyObj("System", ["log"]) });
+        });
+
+        it("debug", () => {
+            container.log("debug", "message");
+            expect(desktop.System.log).toHaveBeenCalledWith("debug", "message", jasmine.any(Function), jasmine.any(Function));
+        });
+
+        it("info", () => {
+            container.log("info", "message");
+            expect(desktop.System.log).toHaveBeenCalledWith("info", "message", jasmine.any(Function), jasmine.any(Function));
+        });
+
+        it("warn", () => {
+            container.log("warn", "message");
+            expect(desktop.System.log).toHaveBeenCalledWith("warn", "message", jasmine.any(Function), jasmine.any(Function));
+        });
+
+        it("error", () => {
+            container.log("error", "message");
+            expect(desktop.System.log).toHaveBeenCalledWith("error", "message", jasmine.any(Function), jasmine.any(Function));
+        });
+    });
+
     it("getMainWindow returns wrapped inner window", () => {
         const win: OpenFinContainerWindow = container.getMainWindow();
         expect(win).toBeDefined();

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -107,6 +107,32 @@ describe("container", () => {
         });
     });
 
+    describe("logging", () => {
+        it("debug", () => {
+            spyOn(console, "debug").and.stub();
+            container.log("debug", "message");
+            expect(console.debug).toHaveBeenCalledWith("message");
+        });
+
+        it("warn", () => {
+            spyOn(console, "warn").and.stub();
+            container.log("warn", "message");
+            expect(console.warn).toHaveBeenCalledWith("message");
+        });
+
+        it("error", () => {
+            spyOn(console, "error").and.stub();
+            container.log("error", "message");
+            expect(console.error).toHaveBeenCalledWith("message");
+        });
+
+        it("info", () => {
+            spyOn(console, "log").and.stub();
+            container.log("info", "message");
+            expect(console.log).toHaveBeenCalledWith("message");
+        });
+    });
+
     describe("ContainerBase", () => {
         describe("addTrayIcon", () => {
             it("Throws Not implemented", () => {


### PR DESCRIPTION
Except for OpenFin, default implementation provided simply redirects to console.<level>. 