### PR TITLE
Provide default implementation of showNotification for Electron

### DIFF
--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -371,7 +371,16 @@ export class ElectronContainer extends WebContainerBase {
     }
 
     public showNotification(title: string, options?: NotificationOptions) {
-        throw new TypeError("showNotification requires an implementation.");
+        const Notification = this.electron.Notification;
+        const notify = new Notification(Object.assign(options || {}, { title: title }));
+        if (options["onClick"]) {
+            notify.addListener("click", options["onClick"]);
+        }
+        if (options["notification"]) {
+            notify.once("show", () => notify.addListener("click", options["notification"]["onclick"]));
+        }
+
+        notify.show();
     }
 
     public addTrayIcon(details: TrayIconDetails, listener: () => void, menuItems?: MenuItem[]) {

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -339,6 +339,13 @@ describe("ElectronContainer", () => {
             Menu: {
                 buildFromTemplate: (menuItems: any) => { }
             },
+            Notification: (options: any) => {
+                return {
+                    show: () => {},
+                    addListener: () => {},
+                    once: () => {}
+                }
+            },
             require: (type: string) => { return {} },
             getCurrentWindow: () => { return windows[0]; }
         };
@@ -441,8 +448,10 @@ describe("ElectronContainer", () => {
     });
 
     describe("notifications", () => {
-        it("showNotification throws not implemented", () => {
-            expect(() => container.showNotification("title", {})).toThrowError(TypeError);
+        it("showNotification delegates to electron notification", () => {
+            spyOn(electron, "Notification").and.callThrough();
+            container.showNotification("title", <any> { onClick: () => {}, notification: { } });
+            expect(electron.Notification).toHaveBeenCalledWith({ title: "title", onClick: jasmine.any(Function), notification: jasmine.any(Object) });
         });
 
         it("requestPermission granted", (done) => {


### PR DESCRIPTION
Implementation simply delegates to Electron.  This still requires a polyfill to be provided (example in app.js) for Windows 7