### PR TITLE
Lower the snap threshold range

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -348,7 +348,7 @@ export class GroupWindowManager {
 export class SnapAssistWindowManager extends GroupWindowManager {
     private readonly floater: ContainerWindow;
     public autoGrouping: boolean = true;
-    public snapThreshold: number = 20;
+    public snapThreshold: number = 15;
     public snapOffset: number = 15;
     private snappingWindow: string;
     protected readonly targetGroup: Map<string, ContainerWindow> = new Map();

--- a/tests/unit/window.spec.ts
+++ b/tests/unit/window.spec.ts
@@ -166,7 +166,7 @@ describe("GroupWindowManager", () => {
 describe("SnapAssistWindowManager", () => {
     it ("default options", () => {
         const mgr = new SnapAssistWindowManager(null);
-        expect(mgr.snapThreshold).toEqual(20);
+        expect(mgr.snapThreshold).toEqual(15);
         expect(mgr.snapOffset).toEqual(15);
         expect(mgr.autoGrouping).toEqual(true);
     });
@@ -317,7 +317,7 @@ describe("SnapAssistWindowManager", () => {
         const container = jasmine.createSpyObj("container", ["getAllWindows"]);
         container.getAllWindows.and.returnValue(Promise.resolve([ win, win2 ]));
 
-        const mgr = new SnapAssistWindowManager(container);
+        const mgr = new SnapAssistWindowManager(container, { snapThreshold: 20 });
         mgr.attach(win);
         callback(new WindowEventArgs(win, "move", undefined));
     });
@@ -326,7 +326,7 @@ describe("SnapAssistWindowManager", () => {
         let mgr;
 
         beforeAll(() => {
-            mgr = new SnapAssistWindowManager(null);
+            mgr = new SnapAssistWindowManager(null, { snapThreshold: 20 });
         });
 
         describe("left edge to right edge", () => {


### PR DESCRIPTION
A lower range makes it easier to break the snap on Electron which had a tendency to be too sticky.  This is a significant improvement for #116 but it still needs future work.