### PR TITLE
Enable smallWindow on OpenFin tray icon context menu window

### DIFF
--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -457,7 +457,8 @@ export class OpenFinContainer extends WebContainerBase {
                 contextMenu: true,
                 resizable: false,
                 alwaysOnTop: true,
-                shadow: true
+                shadow: true,
+                smallWindow: true
             }
             , () => {
                 const win: Window = contextMenu.getNativeWindow();


### PR DESCRIPTION
Remove unnecessary padding when menu has only one item due to minimum size being forced by default with smallWindow not enabled

http://cdn.openfin.co/jsdocs/stable/fin.desktop.Window.html#~options

Before:
![image](https://user-images.githubusercontent.com/28159742/42103371-dad3b7f2-7b96-11e8-8d69-fe8cdb4fb968.png)

After:
![image](https://user-images.githubusercontent.com/28159742/42103350-c8850704-7b96-11e8-8b50-687ceb7edb2d.png)
