### PR TITLE
Fire window-created events for ElectronContainer at the end of the current event loop cycle

### DIFF
--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -283,8 +283,10 @@ export class ElectronContainer extends WebContainerBase {
                 this.windowManager = new ElectronWindowManager(this.app, this.internalIpc, this.browserWindow);
 
                 this.app.on("browser-window-created", (event, window) => {
-                    Container.emit("window-created", { name: "window-created", windowId: window.webContents.id });
-                    ContainerWindow.emit("window-created", { name: "window-created", windowId: window.webContents.id });
+                    setImmediate(() => {
+                        Container.emit("window-created", { name: "window-created", windowId: window.webContents.id });
+                        ContainerWindow.emit("window-created", { name: "window-created", windowId: window.webContents.id });
+                    });
                 });
             }
         } catch (e) {


### PR DESCRIPTION
The GroupWindowManager attaches events to new windows as they are created. The event for window created is fired and provides a window id. Electron has not registered the window internally yet when this event is fired so any attempt to get a reference to the Electron BrowserWindow instance from within the event handler via fromId does not work. The group manager is currently working incorrectly since an undefined window causes it to attach handlers to every window as though it is initial setup. This is causing duplicate handlers.