### PR TITLE
Add support for disabling snap dock for a window via creation

### DIFF
--- a/src/Default/default.ts
+++ b/src/Default/default.ts
@@ -94,6 +94,12 @@ export class DefaultContainerWindow extends ContainerWindow {
         });
     }
 
+    public getOptions(): Promise<any> {
+        return new Promise<any>((resolve, reject) => {
+            resolve(this.innerWindow[Container.windowOptionsPropertyKey]);
+        });
+    }
+
     protected attachListener(eventName: string, listener: (...args: any[]) => void): void {
         this.innerWindow.addEventListener(windowEventMap[eventName] || eventName, listener);
     }

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -25,6 +25,7 @@ class InternalMessageType {
     public static readonly getGroup: string = "desktopJS.window-getGroup";
     public static readonly joinGroup: string = "desktopJS.window-joinGroup";
     public static readonly leaveGroup: string = "desktopJS.window-leaveGroup";
+    public static readonly getOptions: string = "desktopJS.window-getOptions";
 }
 
 const windowEventMap = {};
@@ -162,6 +163,16 @@ export class ElectronContainerWindow extends ContainerWindow {
         }
 
         return Promise.resolve();
+    }
+
+    public getOptions(): Promise<any> {
+        return new Promise<any>((resolve, reject) => {
+            const options = (this.isRemote)
+                ? (<any>this.container.internalIpc).sendSync(InternalMessageType.getOptions, { source: this.id })
+                : this.innerWindow[Container.windowOptionsPropertyKey];
+
+            resolve(options);
+        });
     }
 
     protected attachListener(eventName: string, listener: (...args: any[]) => void): void {
@@ -505,6 +516,11 @@ export class ElectronWindowManager {
         this.ipc.on(InternalMessageType.getGroup, (event: any, message: any) => {
             const { "source": sourceId } = message;
             event.returnValue = this.getGroup(this.browserWindow.fromId(sourceId));
+        });
+
+        this.ipc.on(InternalMessageType.getOptions, (event: any, message: any) => {
+            const { "source": sourceId } = message;
+            event.returnValue = this.browserWindow.fromId(sourceId)[Container.windowOptionsPropertyKey];
         });
     }
 

--- a/src/OpenFin/openfin.ts
+++ b/src/OpenFin/openfin.ts
@@ -151,6 +151,12 @@ export class OpenFinContainerWindow extends ContainerWindow {
         });
     }
 
+    public getOptions(): Promise<any> {
+        return new Promise<any>((resolve, reject) => {
+            this.innerWindow.getOptions(options => resolve(options.customData ? JSON.parse(options.customData) : undefined), reject);
+        });
+    }
+
     protected attachListener(eventName: string, listener: (...args: any[]) => void): void {
         this.innerWindow.addEventListener(windowEventMap[eventName] || eventName, listener);
     }
@@ -411,6 +417,7 @@ export class OpenFinContainer extends WebContainerBase {
 
     protected getWindowOptions(options?: any): any {
         const newOptions = ObjectTransform.transformProperties(options, this.windowOptionsMap);
+        newOptions.customData = options ? JSON.stringify(options) : undefined;
 
         // Default behavior is to show window so if there is no override in options, show the window
         if (!("autoShow" in newOptions)) {

--- a/tests/unit/Default/default.spec.ts
+++ b/tests/unit/Default/default.spec.ts
@@ -128,6 +128,14 @@ describe("DefaultContainerWindow", () => {
         });
     });
 
+    it("getOptions", async (done) => {
+        const win = await new DefaultContainer(<any>new MockWindow()).createWindow("url", { a: "foo" });
+        win.getOptions().then(options => {
+            expect(options).toBeDefined();
+            expect(options).toEqual({ a: "foo"});
+        }).then(done);
+    });    
+
     describe("addListener", () => {
         it("addListener calls underlying window addEventListener with mapped event name", () => {
             spyOn(win.innerWindow, "addEventListener").and.callThrough()

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -224,6 +224,18 @@ describe("ElectronContainerWindow", () => {
             });
         });
 
+        it ("getOptions sends synchronous ipc message", (done) => {
+            spyOn(container.internalIpc, "sendSync").and.returnValue({ foo: "bar"});
+            spyOnProperty(win, "id", "get").and.returnValue(5);
+            spyOn(container, "wrapWindow").and.returnValue(new MockWindow());
+            spyOn(container.browserWindow, "fromId").and.returnValue(innerWin);
+
+            win.getOptions().then(options => {
+                expect(container.internalIpc.sendSync).toHaveBeenCalledWith("desktopJS.window-getOptions", { source: 5});
+                expect(options).toEqual({ foo: "bar" });
+            }).then(done);
+        });
+
         it("addListener calls underlying Electron window addListener", () => {
             spyOn(win.innerWindow, "addListener").and.callThrough()
             win.addListener("move", () => {});
@@ -633,11 +645,12 @@ describe("ElectronWindowManager", () => {
         const ipc = new MockMainIpc();
         spyOn(ipc, "on").and.callThrough();
         new ElectronWindowManager({}, ipc, { });
-        expect(ipc.on).toHaveBeenCalledTimes(4);
+        expect(ipc.on).toHaveBeenCalledTimes(5);
         expect(ipc.on).toHaveBeenCalledWith("desktopJS.window-initialize", jasmine.any(Function));
         expect(ipc.on).toHaveBeenCalledWith("desktopJS.window-joinGroup", jasmine.any(Function));
         expect(ipc.on).toHaveBeenCalledWith("desktopJS.window-leaveGroup", jasmine.any(Function));
         expect(ipc.on).toHaveBeenCalledWith("desktopJS.window-getGroup", jasmine.any(Function));
+        expect(ipc.on).toHaveBeenCalledWith("desktopJS.window-getOptions", jasmine.any(Function));
     });
 
     it ("initializeWindow on non-main does not attach to close", () => {

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -298,6 +298,23 @@ describe("OpenFinContainerWindow", () => {
             });
         });
 
+        describe("getOptions", () => {
+            it("getOptions invokes underlying getOptions and returns undefined customData", (done) => {
+                spyOn(win.innerWindow, "getOptions").and.callFake(callback => callback({ }));
+                win.getOptions().then(options => {
+                    expect(options).toBeUndefined();
+                }).then(done);
+            });
+
+            it("getOptions invokes underlying getOptions and parses non-null customData", (done) => {
+                spyOn(win.innerWindow, "getOptions").and.callFake(callback => callback({ customData: '{ "a": "foo"}' }));
+                win.getOptions().then(options => {
+                    expect(options).toBeDefined();
+                    expect(options.a).toEqual("foo");
+                }).then(done);
+            });
+        });
+
         describe("addListener", () => {
             it("addListener calls underlying OpenFin window addEventListener with mapped event name", () => {
                 spyOn(win.innerWindow, "addEventListener").and.callThrough()
@@ -485,25 +502,25 @@ describe("OpenFinContainer", () => {
         it("defaults", (done) => {
             container.createWindow("url").then(win => {
                 expect(win).toBeDefined();
-                expect(desktop.Window).toHaveBeenCalledWith({ autoShow: true, url: "url", name: jasmine.stringMatching(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/) }, jasmine.any(Function), jasmine.any(Function));
+                expect(desktop.Window).toHaveBeenCalledWith({ autoShow: true, url: "url", name: jasmine.stringMatching(/\w{8}-\w{4}-\w{4}-\w{4}-\w{12}/), customData: undefined }, jasmine.any(Function), jasmine.any(Function));
                 done();
             });
         });
 
         it("createWindow defaults", (done) => {
             spyOn<any>(container, "ensureAbsoluteUrl").and.returnValue("absoluteIcon");
+            const options = {
+                x: "x",
+                y: "y",
+                height: "height",
+                width: "width",
+                taskbar: "taskbar",
+                center: "center",
+                icon: "icon",
+                name: "name"
+            }
 
-            container.createWindow("url",
-                {
-                    x: "x",
-                    y: "y",
-                    height: "height",
-                    width: "width",
-                    taskbar: "taskbar",
-                    center: "center",
-                    icon: "icon",
-                    name: "name"
-                }).then(win => {
+            container.createWindow("url", options).then(win => {
                     expect(win).toBeDefined();
                     expect(desktop.Window).toHaveBeenCalledWith(
                         {
@@ -517,7 +534,8 @@ describe("OpenFinContainer", () => {
                             autoShow: true,
                             saveWindowState: false,
                             url: "url",
-                            name: "name"
+                            name: "name",
+                            customData: JSON.stringify(options)
                         },
                         jasmine.any(Function),
                         jasmine.any(Function)


### PR DESCRIPTION
* Add getOptions() to base ContainerWindow and implement in each concrete.
* Support disable of individual windows from participating in snap docking with snap parameter in custom options to createWindow().
    `container.createWindow(url, { snap: false });`