### PR TITLE
Add project .npmrc to specify npmjs registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/examples/electron/.npmrc
+++ b/examples/electron/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Specify project level registry to override local global settings for users that are in an environment with their own private registry.  This will allow the package-lock to be added and provide more certainty that by default the registry for any new packages will stay npmjs.