### PR TITLE
Add ability for windows to save custom state as part of the persisted window layout

### DIFF
--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -203,3 +203,13 @@ loadlayoutButton.onclick = function () {
 savelayoutButton.onclick = function () {
 	container.saveLayout("Layout");
 };
+
+/** Invoked by window layout saving to maintain state specific to this window */
+function getState() {
+	return { value: "Foo" };
+}
+
+/** Invoked by window layout loading to restore state specific to this window */
+function setState(state) {
+	this.container.log("info", state);
+}

--- a/src/Electron/electron.ts
+++ b/src/Electron/electron.ts
@@ -190,7 +190,7 @@ export class ElectronContainerWindow extends ContainerWindow {
 
     public getState(): Promise<any> {
         if (this.innerWindow && this.innerWindow.webContents) {
-            return this.innerWindow.webContents.executeJavaScript("getState ? getState() : undefined");
+            return this.innerWindow.webContents.executeJavaScript("window.getState ? window.getState() : undefined");
         } else {
             return Promise.resolve(undefined);
         }
@@ -198,7 +198,7 @@ export class ElectronContainerWindow extends ContainerWindow {
 
     public setState(state: any): Promise<void> {
         if (this.innerWindow && this.innerWindow.webContents) {
-            return this.innerWindow.webContents.executeJavaScript(`if (setState) setState(JSON.parse(\`${JSON.stringify(state)}\`))`);
+            return this.innerWindow.webContents.executeJavaScript(`if (window.setState) { window.setState(JSON.parse(\`${JSON.stringify(state)}\`)); }`);
         } else {
             return Promise.resolve();
         }

--- a/src/container.ts
+++ b/src/container.ts
@@ -193,8 +193,12 @@ export abstract class ContainerBase extends Container {
 
                         // de-dupe window grouping
                         windows.forEach(window => {
-                            let found = false;
+                            const matchingWindow = layout.windows.find(win => win.name === window.name);
+                            if (matchingWindow && matchingWindow.state && window.setState) {
+                                window.setState(matchingWindow.state).catch(e => this.log("error", "Error invoking setState: " + e));
+                            }
 
+                            let found = false;
                             groupMap.forEach((targets, win) => {
                                 if (!found && targets.indexOf(window.id) >= 0) {
                                     found = true;
@@ -202,7 +206,6 @@ export abstract class ContainerBase extends Container {
                             });
 
                             if (!found) {
-                                const matchingWindow = layout.windows.find(win => win.name === window.name);
                                 const group = matchingWindow ? matchingWindow.group : undefined;
                                 if (group && group.length > 0) {
                                     groupMap.set(window, group.filter(id => id !== window.id));

--- a/src/window.ts
+++ b/src/window.ts
@@ -144,6 +144,16 @@ export abstract class ContainerWindow extends EventEmitter {
 
     public abstract getOptions(): Promise<any>;
 
+    /** Retrieves custom window state from underlying native window by invoking 'window.getState()' if defined. */
+    public getState(): Promise<any> {
+        return Promise.resolve(undefined);
+    }
+
+    /** Provide custom window state to underlying native window by invoking 'window.setState()' if defined */
+    public setState(state: any): Promise<void> {
+        return Promise.resolve();
+    }
+
     /** Gets the underlying native JavaScript window object. As some containers
      * do not support native access, check for undefined.
      */
@@ -265,6 +275,7 @@ export class PersistedWindow {
     public id: string;
     public bounds: any;
     public options?: any;
+    public state?: any;
     public url?: string;
     public main?: boolean;
     public group?: string[];

--- a/tests/unit/Electron/electron.spec.ts
+++ b/tests/unit/Electron/electron.spec.ts
@@ -31,7 +31,6 @@ class MockWindow extends MockEventEmitter {
     public id: number;
     public group: string;
     private bounds: any = { x: 0, y: 1, width: 2, height: 3 }
-    public innerWindow: any = {};
 
     constructor(name?: string) {
         super();
@@ -55,7 +54,8 @@ class MockWindow extends MockEventEmitter {
 
     public webContents: any = {
         send(channel: string, ...args: any[]) { },
-        getURL() { return "url"; }
+        getURL() { return "url"; },
+        executeJavaScript() {}
     }
 
     public getBounds(): any { return this.bounds; }
@@ -190,6 +190,47 @@ describe("ElectronContainerWindow", () => {
                 expect(success).toEqual(true);
                 expect(innerWin.isVisible).toHaveBeenCalled();
             }).then(done);
+        });
+
+        describe("getState", () => {
+            it("getState undefined", (done) => {
+                let mockWindow = new MockWindow();
+                mockWindow.webContents = null;
+                let win = new ElectronContainerWindow(mockWindow, container);
+
+                win.getState().then(state => {
+                    expect(state).toBeUndefined();
+                }).then(done);
+            });
+
+            it("getState defined", (done) => {
+                const mockState = { value: "Foo" };
+                spyOn(innerWin.webContents, "executeJavaScript").and.returnValue(Promise.resolve(mockState));
+                
+                win.getState().then(state => {
+                    expect(innerWin.webContents.executeJavaScript).toHaveBeenCalled();
+                    expect(state).toEqual(mockState);
+                }).then(done);
+            });
+        });        
+    
+        describe("setState", () => {
+            it("setState undefined", (done) => {
+                let mockWindow = new MockWindow();
+                mockWindow.webContents = null;
+                let win = new ElectronContainerWindow(mockWindow, container);
+
+                win.setState({}).then(done);
+            });
+
+            it("setState defined", (done) => {
+                const mockState = { value: "Foo" };
+                spyOn(innerWin.webContents, "executeJavaScript").and.returnValue(Promise.resolve());
+
+                win.setState(mockState).then(() => {
+                    expect(innerWin.webContents.executeJavaScript).toHaveBeenCalled();
+                }).then(done);  
+            });
         });
 
         it("getSnapshot", (done) => {

--- a/tests/unit/OpenFin/openfin.spec.ts
+++ b/tests/unit/OpenFin/openfin.spec.ts
@@ -57,7 +57,7 @@ class MockInterApplicationBus {
 
 class MockWindow {
     static singleton: MockWindow = new MockWindow("Singleton");
-    public nativeWindow: Window = jasmine.createSpyObj("window", ["location"]);
+    public nativeWindow: Window = jasmine.createSpyObj("window", ["location", "getState", "setState"]);
 
     constructor(name?: string) {
         this.name = name;
@@ -258,6 +258,48 @@ describe("OpenFinContainerWindow", () => {
             expect(innerWin.isShowing).toHaveBeenCalled();
         }).then(done);
     });
+
+
+    describe("getState", () => {
+        it("getState undefined", (done) => {
+            let mockWindow = new MockWindow();
+            delete (<any>mockWindow.nativeWindow).getState;
+            let win = new OpenFinContainerWindow(innerWin);
+
+            win.getState().then(state => {
+                expect(state).toBeUndefined();
+            }).then(done);
+        });
+
+        it("getState defined", (done) => {
+            const mockState = { value: "Foo" };
+            innerWin.nativeWindow.getState.and.returnValue(mockState);
+    
+            win.getState().then(state => {
+                expect(innerWin.nativeWindow.getState).toHaveBeenCalled();
+                expect(state).toEqual(mockState);
+            }).then(done);
+        });
+        });        
+
+    describe("setState", () => {
+        it("setState undefined", (done) => {
+            let mockWindow = new MockWindow();
+            delete (<any>mockWindow.nativeWindow).setState;
+            let win = new OpenFinContainerWindow(innerWin);
+
+            win.setState({}).then(done);
+        });
+
+        it("setState defined", (done) => {
+            const mockState = { value: "Foo" };
+            innerWin.nativeWindow.setState.and.returnValue(Promise.resolve());
+    
+            win.setState(mockState).then(() => {
+                expect(innerWin.nativeWindow.setState).toHaveBeenCalledWith(mockState);
+            }).then(done);
+        });
+        });
 
     describe("getSnapshot", () => {
         it("getSnapshot invokes underlying getSnapshot", (done) => {

--- a/tests/unit/container.spec.ts
+++ b/tests/unit/container.spec.ts
@@ -28,8 +28,10 @@ export class MockMessageBus implements MessageBus { // tslint:disable-line
 
 export class TestContainer extends ContainerBase {
     getMainWindow(): ContainerWindow {
-        const win = jasmine.createSpyObj("ContainerWindow", ["setBounds"]);
+        const win = jasmine.createSpyObj("ContainerWindow", ["setBounds", "getState", "setState"]);
         Object.defineProperty(win, "name", { value: "1" });
+        win.getState.and.returnValue(Promise.resolve({}));
+        win.setState.and.returnValue(Promise.resolve());
         return win;
     }
 
@@ -40,9 +42,11 @@ export class TestContainer extends ContainerBase {
     }
 
     createWindow(url: string, options?: any): Promise<ContainerWindow> {
-        const win = jasmine.createSpyObj("ContainerWindow", ["id"]);
+        const win = jasmine.createSpyObj("ContainerWindow", ["id", "getState", "setState"]);
         Object.defineProperty(win, "name", { value: options.name || "1" });
         Object.defineProperty(win, "id", { value: options.name || "1" });
+        win.getState.and.returnValue(Promise.resolve({}));
+        win.setState.and.returnValue(Promise.resolve());
         return Promise.resolve(win);
     }
 
@@ -54,7 +58,7 @@ export class TestContainer extends ContainerBase {
         this.storage = <any> {
             getItem(key: string): string {
                 const layout: PersistedWindowLayout = new PersistedWindowLayout();
-                layout.windows.push({ name: "1", id: "1", url: "url", bounds: {}, group: ["1", "2", "3"]});
+                layout.windows.push({ name: "1", id: "1", url: "url", bounds: {}, state: { "value": "foo" }, group: ["1", "2", "3"]});
                 layout.windows.push({ name: "2", id: "2", main: true, url: "url", bounds: {}, group: ["1", "2", "3"]});
                 layout.windows.push({ name: "3", id: "3", url: "url", bounds: {}, group: ["1", "2", "3"]});
                 layout.name = "Test";

--- a/tests/unit/window.spec.ts
+++ b/tests/unit/window.spec.ts
@@ -16,6 +16,18 @@ describe ("ContainerWindow", () => {
     it("nativeWindow returns undefined", () => {
         expect(new MockWindow(undefined).nativeWindow).toBeUndefined();
     });
+
+    it("getState returns undefined", (done) => {
+        new MockWindow(undefined).getState().then(state => {
+            expect(state).toBeUndefined();
+        }).then(done);
+    });
+
+    it("setState returns", (done) => {
+        new MockWindow(undefined).setState({}).then(() => {
+            expect(true);
+        }).then(done);
+    });
 });
 
 describe ("static events", () => {


### PR DESCRIPTION
State will be provided back to the window upon layout load.  If the underlying native js window has getState/setState defined they will be invoked.