### PR TITLE
Add window.bringToFront()

### DIFF
--- a/packages/desktopjs-electron/src/electron.ts
+++ b/packages/desktopjs-electron/src/electron.ts
@@ -177,6 +177,13 @@ export class ElectronContainerWindow extends ContainerWindow {
         return Promise.resolve();
     }
 
+    public bringToFront(): Promise<void> {
+        return new Promise<void>(resolve => {
+            this.innerWindow.moveTop();
+            resolve();
+        });
+    }
+
     public getOptions(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             const options = (this.isRemote)

--- a/packages/desktopjs-electron/tests/electron.spec.ts
+++ b/packages/desktopjs-electron/tests/electron.spec.ts
@@ -65,7 +65,9 @@ class MockWindow extends MockEventEmitter {
         this.emit("move", null);
      }
 
-     public flashFrame(enable: boolean): void { }
+    public flashFrame(enable: boolean): void { }
+
+    public moveTop(): void { }
 }
 
 class MockCapture {
@@ -407,6 +409,13 @@ describe("ElectronContainerWindow", () => {
             win.leaveGroup();
             expect((<any>container).windowManager.ungroupWindows).toHaveBeenCalled();
         });
+    });
+
+    it ("bringToFront invokes underlying moveTop", (done) => {
+        spyOn(win.innerWindow, "moveTop").and.callThrough()
+        win.bringToFront().then(() => {
+            expect(innerWin.moveTop).toHaveBeenCalled();
+        }).then(done);
     });
 });
 

--- a/packages/desktopjs-openfin/src/openfin.ts
+++ b/packages/desktopjs-openfin/src/openfin.ts
@@ -155,6 +155,12 @@ export class OpenFinContainerWindow extends ContainerWindow {
         });
     }
 
+    public bringToFront(): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            this.innerWindow.bringToFront(resolve, reject);
+        });
+    }
+
     public getOptions(): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             this.innerWindow.getOptions(options => resolve(options.customData ? JSON.parse(options.customData) : undefined), reject);

--- a/packages/desktopjs-openfin/tests/openfin.spec.ts
+++ b/packages/desktopjs-openfin/tests/openfin.spec.ts
@@ -151,6 +151,10 @@ class MockWindow {
     joinGroup(target: any, callback: any, errorCallback: any) { }
     leaveGroup(callback: any, errorCallback: any) { }
 
+    bringToFront(callback:any, errorCallback: any) {
+        callback();
+    }
+
     addEventListener(eventName: string, listener: any): void { }
 
     removeEventListener(eventName: string, listener: any): void { }
@@ -473,6 +477,13 @@ describe("OpenFinContainerWindow", () => {
                 expect(innerWin.leaveGroup).toHaveBeenCalled();
             }).then(done);
         });
+    });
+
+    it("bringToFront invokes underlying bringToFront", (done) => {
+        spyOn(innerWin, "bringToFront").and.callThrough();
+        win.bringToFront().then(() => {
+            expect(innerWin.bringToFront).toHaveBeenCalled();
+        }).then(done);
     });
 });
 

--- a/packages/desktopjs/src/window.ts
+++ b/packages/desktopjs/src/window.ts
@@ -145,6 +145,11 @@ export abstract class ContainerWindow extends EventEmitter {
         return Promise.resolve();
     }
 
+    public bringToFront(): Promise<void> {
+        // Provide simple delegation to focus/activate by default
+        return this.focus();
+    }
+
     public abstract getOptions(): Promise<any>;
 
     /** Retrieves custom window state from underlying native window by invoking 'window.getState()' if defined. */

--- a/packages/desktopjs/tests/unit/window.spec.ts
+++ b/packages/desktopjs/tests/unit/window.spec.ts
@@ -9,6 +9,7 @@ class MockWindow extends ContainerWindow {
         return;
     }
 
+    public focus(): Promise<void> { return Promise.resolve(); }
     public minimize(): Promise<void> { return Promise.resolve(); }
     public restore(): Promise<void> { return Promise.resolve(); }
 }
@@ -28,6 +29,14 @@ describe ("ContainerWindow", () => {
         new MockWindow(undefined).setState({}).then(() => {
             expect(true);
         }).then(done);
+    });
+
+    it("bringToFront invokes focus by default", (done) => {
+        const win = new MockWindow(undefined)
+        spyOn(win, "focus").and.callThrough();
+        win.bringToFront().then(() =>  {
+            expect(win.focus).toHaveBeenCalled();
+        }).then(done);     
     });
 });
 


### PR DESCRIPTION
Raise z-order of a window without activating.  Default implementation will fallback to invoking focus() for containers in which it is not supported.