### PR TITLE
Update dependencies

### DIFF
--- a/.gulp/tasks/build.js
+++ b/.gulp/tasks/build.js
@@ -20,7 +20,7 @@ module.exports = function (gulp, pkg, config, name, input, iffe, preventReload) 
                     // Wrap umd with a condition checking if desktopJS is already defined to not overwrite it.  This will allow
                     // preload registration of desktopJS without hosted web script includes redefining.
                     gulp.src(pkg.main)
-                        .pipe(replace(/(\(function \(global, factory\)[\s\S]*}\)\)\);)([\s\S]*)/, "if (typeof desktopJS === \"undefined\") {$1}$2"))
+                        .pipe(replace(/(\(function \(global, factory\)[\s\S]*}\)\);)([\s\S]*)/, "if (typeof desktopJS === \"undefined\") {$1}$2"))
                         .pipe(clean())
                         .pipe(gulp.dest(config.dest));
                 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1264,9 +1264,9 @@
       "dev": true
     },
     "@types/fs-extra": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.4.tgz",
-      "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.0.5.tgz",
+      "integrity": "sha512-w7iqhDH9mN8eLClQOYTkhdYUOSpp25eXxfc6VbFOGtzxW34JcvctH2bKjj4jD4++z4R5iO5D+pg48W2e03I65A==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -1295,9 +1295,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.120",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.120.tgz",
-      "integrity": "sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw==",
+      "version": "4.14.121",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.121.tgz",
+      "integrity": "sha512-ORj7IBWj13iYufXt/VXrCNMbUuCTJfhzme5kx9U/UtcIPdJYuvPDUAlHlbNhz/8lKCLy9XGIZnGrqXOtQbPGoQ==",
       "dev": true
     },
     "@types/marked": {
@@ -1325,9 +1325,9 @@
       "dev": true
     },
     "@types/shelljs": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.2.tgz",
-      "integrity": "sha512-vVp7BCQn0yUQgpiohrdxAhHdm/bTlXshB4HG3LEBq1PgvjKiyeYHohIPIv0QBt/jipb140iMS5Xy1iR6qKovKw==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-miY41hqc5SkRlsZDod3heDa4OS9xv8G77EMBQuSpqq86HBn66l7F+f8y9YKm+1PIuwC8QEZVwN8YxOOG7Y67fA==",
       "dev": true,
       "requires": {
         "@types/glob": "*",
@@ -1400,7 +1400,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "ansi-colors": {
       "version": "1.1.0",
@@ -8428,31 +8429,28 @@
       }
     },
     "remap-istanbul": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.12.0.tgz",
-      "integrity": "sha512-lpA+zkWfT7v81k76asd+w82+dnbBTmBEsyuBVQ28armnOqsZZO23uI4ZCBGd8TtIb9Tq4CauswB+A44cbkuiMA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.13.0.tgz",
+      "integrity": "sha512-rS5ZpVAx3fGtKZkiBe1esXg5mKYbgW9iz8kkADFt3p6lo3NsBBUX1q6SwdhwUtYCGnr7nK6gRlbYK3i8R0jbRA==",
       "dev": true,
       "requires": {
-        "amdefine": "^1.0.0",
         "istanbul": "0.4.5",
-        "minimatch": "^3.0.3",
-        "plugin-error": "^0.1.2",
-        "source-map": "^0.6.1",
-        "through2": "2.0.1"
+        "minimatch": "^3.0.4",
+        "plugin-error": "^1.0.1",
+        "source-map": "0.6.1",
+        "through2": "3.0.0"
       },
       "dependencies": {
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
           }
         },
         "source-map": {
@@ -8461,20 +8459,14 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
         "through2": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.1.tgz",
-          "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.0.tgz",
+          "integrity": "sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "~2.0.0",
-            "xtend": "~4.0.0"
+            "readable-stream": "2 || 3",
+            "xtend": "~4.0.1"
           }
         }
       }
@@ -8700,13 +8692,22 @@
       }
     },
     "rollup": {
-      "version": "0.67.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.67.4.tgz",
-      "integrity": "sha512-AVuP73mkb4BBMUmksQ3Jw0jTrBTU1i7rLiUYjFxLZGb3xiFmtVEg40oByphkZAsiL0bJC3hRAJUQos/e5EBd+w==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.1.2.tgz",
+      "integrity": "sha512-OkdMxqMl8pWoQc5D8y1cIinYQPPLV8ZkfLgCzL6SytXeNA2P7UHynEQXI9tYxuAjAMsSyvRaWnyJDLHMxq0XAg==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*"
+        "@types/node": "*",
+        "acorn": "^6.0.5"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
+          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+          "dev": true
+        }
       }
     },
     "rollup-plugin-commonjs": {
@@ -9888,9 +9889,9 @@
       "dev": true
     },
     "typedoc": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.13.0.tgz",
-      "integrity": "sha512-jQWtvPcV+0fiLZAXFEe70v5gqjDO6pJYJz4mlTtmGJeW2KRoIU/BEfktma6Uj8Xii7UakuZjbxFewl3UYOkU/w==",
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
+      "integrity": "sha512-aEbgJXV8/KqaVhcedT7xG6d2r+mOvB5ep3eIz1KuB5sc4fDYXcepEEMdU7XSqLFO5hVPu0nllHi1QxX2h/QlpQ==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^5.0.3",
@@ -9902,20 +9903,20 @@
         "@types/shelljs": "^0.8.0",
         "fs-extra": "^7.0.0",
         "handlebars": "^4.0.6",
-        "highlight.js": "^9.0.0",
+        "highlight.js": "^9.13.1",
         "lodash": "^4.17.10",
         "marked": "^0.4.0",
         "minimatch": "^3.0.0",
         "progress": "^2.0.0",
         "shelljs": "^0.8.2",
         "typedoc-default-themes": "^0.5.0",
-        "typescript": "3.1.x"
+        "typescript": "3.2.x"
       },
       "dependencies": {
         "typescript": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
-          "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.4.tgz",
+          "integrity": "sha512-0RNDbSdEokBeEAkgNbxJ+BLwSManFy9TeXz8uW+48j/xhEXv1ePME60olyzw2XzUqUBNAYFeJadIqAgNqIACwg==",
           "dev": true
         }
       }
@@ -9927,9 +9928,9 @@
       "dev": true
     },
     "typedoc-plugin-external-module-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-1.1.3.tgz",
-      "integrity": "sha512-/VMawTW4NnUUsgq0o8O37y9MmXFaOCDrH1dvDg7SZUS5ZSpUPSILVWwGJP+7g4I8vKZ5bBKZKHfPIEA4xUC+PQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-external-module-name/-/typedoc-plugin-external-module-name-2.0.0.tgz",
+      "integrity": "sha512-BJONvKQWolyNqnzjKQIJflsuvyjapsCPR07maHiRvUOXIbhY56SqmYs+VKevq7SIFXsnlfTEE7meP+6Y/Q2Pyw==",
       "dev": true
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "gulp-uglify": "^3.0.1",
     "lerna": "^3.4.3",
     "merge2": "^1.2.3",
-    "remap-istanbul": "^0.12.0",
-    "rollup": "^0.67.1",
+    "remap-istanbul": "^0.13.0",
+    "rollup": "^1.1.2",
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-sourcemaps": "^0.4.2",
@@ -43,8 +43,8 @@
     "run-sequence": "^2.2.1",
     "tslint": "^5.11.0",
     "tslint-microsoft-contrib": "^6.0.0",
-    "typedoc": "^0.13.0",
-    "typedoc-plugin-external-module-name": "^1.1.3",
+    "typedoc": "^0.14.2",
+    "typedoc-plugin-external-module-name": "^2.0.0",
     "typescript": "^3.1.6"
   }
 }


### PR DESCRIPTION
- typedoc@0.14.2
- typedoc-plugin-external-module-name@2.0.0
- rollup@1.1.1
- remap-istanbul@0.13.0

build.js:
- Upgrade in rollup reduced unnecesary depth of bundle declaration so an update to the regex was required for our wrapping of the bundlne with an undefined check for desktopJS

Closes #211
Closes #212
Closes #222
Closes #223