### PR TITLE
Disable OpenFin window frame whenever enabled.

### DIFF
--- a/packages/desktopjs/src/window.ts
+++ b/packages/desktopjs/src/window.ts
@@ -424,6 +424,7 @@ export class SnapAssistWindowManager extends GroupWindowManager {
         if (isOpenFin()) {
             // OpenFin moved handler
             win.addListener(<WindowEventType>"disabled-frame-bounds-changed", () => this.onMoved(win));
+            win.addListener(<WindowEventType>"frame-enabled", () => win.innerWindow.disableFrame());
         } else {
             // Electron windows specific moved handler
             if (win.innerWindow && win.innerWindow.hookWindowMessage) {


### PR DESCRIPTION
When OpenFin windows are ungrouped the frame is re-enabled.  Attach to the enable event and disable the frame so it is immediately disabled and we can continue to use snap dock

Fixes #225