### PR TITLE
Remove wrapping of module with define check

### DIFF
--- a/.gulp/tasks/build.js
+++ b/.gulp/tasks/build.js
@@ -8,22 +8,13 @@ var rollup = require('rollup'),
     commonjs = require('rollup-plugin-commonjs'),
     typescript = require('typescript');
 
-module.exports = function (gulp, pkg, config, name, input, iffe, preventReload) {
+module.exports = function (gulp, pkg, config, name, input, iffe) {
     return function () {
         // Main bundle is umd
         return createBundle('umd', pkg.main)
             .then(function () {
                 // Generate iife for use as a V8 extension if necessary since umd isn't supported
                 createBundle('iife', config.dest + iffe);
-            }).then(function () {
-                if (preventReload) {
-                    // Wrap umd with a condition checking if desktopJS is already defined to not overwrite it.  This will allow
-                    // preload registration of desktopJS without hosted web script includes redefining.
-                    gulp.src(pkg.main)
-                        .pipe(replace(/(\(function \(global, factory\)[\s\S]*}\)\);)([\s\S]*)/, "if (typeof desktopJS === \"undefined\") {$1}$2"))
-                        .pipe(clean())
-                        .pipe(gulp.dest(config.dest));
-                }
             });
 
         function createBundle(format, destination) {

--- a/packages/desktopjs/gulpfile.js
+++ b/packages/desktopjs/gulpfile.js
@@ -7,7 +7,7 @@ var gulp = require('gulp'),
 gulp.task('tslint', require('../../.gulp/tasks/tslint')(gulp, gulpConfig));
 gulp.task('clean:staging', require('../../.gulp/tasks/clean')(gulp, gulpConfig.staging.dest));
 gulp.task('clean', gulp.series(['clean:staging'], require('../../.gulp/tasks/clean')(gulp, gulpConfig.dest)));
-gulp.task('build:main', require('../../.gulp/tasks/build')(gulp, pkg, gulpConfig, 'desktopJS', 'src/desktop.ts', '/iffe/desktop.js', true));
+gulp.task('build:main', require('../../.gulp/tasks/build')(gulp, pkg, gulpConfig, 'desktopJS', 'src/desktop.ts', '/iffe/desktop.js'));
 gulp.task('build:staging', require('../../.gulp/tasks/stage')(gulp, gulpConfig));
 gulp.task('test', gulp.series(['build:staging'], require('../../.gulp/tasks/tests')(gulp, gulpConfig)));
 gulp.task('dts', require('../../.gulp/tasks/dts')(gulp, pkg.name, gulpConfig.staging.dest + "/src/desktop.d.ts", "../../" + pkg.types));


### PR DESCRIPTION
While this was useful for those that do script includes, it simply prevents any bundler/packager from working.