### PR TITLE
Add state to state-changed event args

### DIFF
--- a/packages/desktopjs-electron/src/electron.ts
+++ b/packages/desktopjs-electron/src/electron.ts
@@ -5,7 +5,8 @@
 import {
     registerContainer, ContainerWindow, PersistedWindowLayout, Rectangle, Container, WebContainerBase,
     ScreenManager, Display, Point, ObjectTransform, PropertyMap, NotificationOptions, ContainerNotification,
-    TrayIconDetails, MenuItem, Guid, MessageBus, MessageBusSubscription, MessageBusOptions, GlobalShortcutManager
+    TrayIconDetails, MenuItem, Guid, MessageBus, MessageBusSubscription, MessageBusOptions, GlobalShortcutManager,
+    EventArgs, WindowEventArgs
 } from "@morgan-stanley/desktopjs";
 
 registerContainer("Electron", {
@@ -208,8 +209,8 @@ export class ElectronContainerWindow extends ContainerWindow {
             : Promise.resolve();
 
         return promise.then(() => {
-            this.emit("state-changed", { name: "state-changed", sender: this });
-            ContainerWindow.emit("state-changed", { name: "state-changed", windowId: this.id } );
+            this.emit("state-changed", <EventArgs> { name: "state-changed", sender: this, state: state });
+            ContainerWindow.emit("state-changed", <WindowEventArgs> { name: "state-changed", windowId: this.id, state: state } );
         });
     }
 

--- a/packages/desktopjs-openfin/src/openfin.ts
+++ b/packages/desktopjs-openfin/src/openfin.ts
@@ -6,7 +6,7 @@ import {
     registerContainer, ContainerWindow, PersistedWindowLayout, Rectangle, Container, WebContainerBase,
     ScreenManager, Display, Point, ObjectTransform, PropertyMap, NotificationOptions, ContainerNotification,
     TrayIconDetails, MenuItem, Guid, MessageBus, MessageBusSubscription, MessageBusOptions, EventArgs,
-    GlobalShortcutManager
+    GlobalShortcutManager, WindowEventArgs
 } from "@morgan-stanley/desktopjs";
 
 registerContainer("OpenFin", {
@@ -188,8 +188,8 @@ export class OpenFinContainerWindow extends ContainerWindow {
 
             resolve();
         }).then(() => {
-            this.emit("state-changed", { name: "state-changed", sender: this });
-            ContainerWindow.emit("state-changed", { name: "state-changed", windowId: this.id } );
+            this.emit("state-changed", <EventArgs> { name: "state-changed", sender: this, state: state });
+            ContainerWindow.emit("state-changed", <WindowEventArgs> { name: "state-changed", windowId: this.id, state: state } );
         });
     }
 

--- a/packages/desktopjs/src/Default/default.ts
+++ b/packages/desktopjs/src/Default/default.ts
@@ -3,12 +3,13 @@
  */
 
 import { Container, WebContainerBase } from "../container";
-import { ContainerWindow, PersistedWindowLayout, Rectangle } from "../window";
+import { ContainerWindow, PersistedWindowLayout, Rectangle, WindowEventArgs } from "../window";
 import { ScreenManager, Display, Point } from "../screen";
 import { NotificationOptions } from "../notification";
 import { ObjectTransform, PropertyMap } from "../propertymapping";
 import { Guid } from "../guid";
 import { MessageBus, MessageBusSubscription, MessageBusOptions } from "../ipc";
+import { EventArgs } from "../events";
 
 declare var Notification: any;
 
@@ -126,8 +127,8 @@ export namespace Default {
 
                 resolve();
             }).then(() => {
-                this.emit("state-changed", { name: "state-changed", sender: this });
-                ContainerWindow.emit("state-changed", { name: "state-changed", windowId: this.id } );
+                this.emit("state-changed", <EventArgs> { name: "state-changed", sender: this, state: state });
+                ContainerWindow.emit("state-changed", <WindowEventArgs> { name: "state-changed", windowId: this.id, state: state } );
             });
         }
 


### PR DESCRIPTION
For subscribers, prevent having to invoke getWindowById and getState by including in event arguments

Fixes #255