### PR TITLE
Add node option to createWindow and resolveContainer of ElectronContainer

### DIFF
--- a/examples/electron/electron.js
+++ b/examples/electron/electron.js
@@ -7,7 +7,7 @@ let mainWindow;
 let snapAssist;
 
 function createWindow() {
-    let container = desktopJS.resolveContainer();
+    let container = desktopJS.resolveContainer({node: true});
 
     desktopJS.ContainerWindow.addListener("window-created", (e) => container.log("info", "Window created - static (ContainerWindow): " + e.windowId + ", " + e.windowName));
 	desktopJS.ContainerWindow.addListener("window-joinGroup", (e) => container.log("info", "grouped " + JSON.stringify(e)));

--- a/examples/web/assets/js/app.js
+++ b/examples/web/assets/js/app.js
@@ -62,7 +62,7 @@ desktopJS.Electron.ElectronContainer.prototype.showNotification = function (titl
 document.addEventListener("DOMContentLoaded", function (event) {
 	updatefps();
 
-	container = desktopJS.resolveContainer();
+	container = desktopJS.resolveContainer({node: true});
 
 	container.ready().then(() => {
 		hostName.innerHTML = container.hostType + " &#8226; " + container.uuid + " &#8226; " + desktopJS.version;

--- a/packages/desktopjs-electron/tests/electron.spec.ts
+++ b/packages/desktopjs-electron/tests/electron.spec.ts
@@ -523,8 +523,8 @@ describe("ElectronContainer", () => {
 
     it("createWindow", (done) => {
         spyOn<any>(container, "browserWindow").and.callThrough();
-        container.createWindow("url", { x: "x", taskbar: false }).then(done);
-        expect((<any>container).browserWindow).toHaveBeenCalledWith({ x: "x", skipTaskbar: true });
+        container.createWindow("url", { x: "x", taskbar: false, node: true }).then(done);
+        expect((<any>container).browserWindow).toHaveBeenCalledWith({ x: "x", skipTaskbar: true, webPreferences: { nodeIntegration: true } });
     });
 
     it("createWindow fires window-created", (done) => {
@@ -545,6 +545,22 @@ describe("ElectronContainer", () => {
         const options = { name: "name" };
         container.createWindow("url", options).then(done);
         expect((<any>container).windowManager.initializeWindow).toHaveBeenCalledWith(jasmine.any(Object), "name", options);
+    });
+
+    it("createWindow pulls nodeIntegration default from container", (done) => {
+        const container = new ElectronContainer(electron, new MockIpc(), globalWindow, { node: true });
+        spyOn<any>(container, "browserWindow").and.callThrough();
+        container.createWindow("url", { }).then(() => {
+            expect(container.browserWindow).toHaveBeenCalledWith({ webPreferences: { nodeIntegration: true }});
+        }).then(done);
+    });
+
+    it("createWindow with node specified ignores container default", (done) => {
+        const container = new ElectronContainer(electron, new MockIpc(), globalWindow, { node: true });
+        spyOn<any>(container, "browserWindow").and.callThrough();
+        container.createWindow("url", { node: false }).then(() => {
+            expect(container.browserWindow).toHaveBeenCalledWith({ webPreferences: { nodeIntegration: false }});
+        }).then(done);
     });
 
     it("addTrayIcon", () => {


### PR DESCRIPTION
Specify default for container for all new windows via:

`resolveContainer({node: true})`

Specify for individual new window (overrides container default if defined):

`createWindow(url, {node: true });`

Fixes #259