### PR TITLE
Add location defined check in base buildLayout

### DIFF
--- a/packages/desktopjs/src/Default/default.ts
+++ b/packages/desktopjs/src/Default/default.ts
@@ -401,7 +401,7 @@ export namespace Default {
                                 layout.windows.push(
                                     {
                                         name: window.name,
-                                        url: nativeWin.location.toString(),
+                                        url: (nativeWin && nativeWin.location) ? nativeWin.location.toString() : undefined,
                                         id: window.id,
                                         bounds: { x: nativeWin.screenX, y: nativeWin.screenY, width: nativeWin.outerWidth, height: nativeWin.outerHeight },
                                         options: options,


### PR DESCRIPTION
As DefaultContainer is the base default implemenation of buildLayout, derived implementations might not support location (div based windows) and fail to be able to persist layouts.

Fixes #266