### PR TITLE
Update loadLayout to take a layout name or the layout itself to apply

### DIFF
--- a/packages/desktopjs/src/window.ts
+++ b/packages/desktopjs/src/window.ts
@@ -263,10 +263,11 @@ export interface ContainerWindowManager {
     createWindow(url: string, options?: any): Promise<ContainerWindow>;
 
     /**
-     * Loads a window layout from persistence
-     * @param {string} name - Name of the window layout to load
+     * Loads a window layout
+     * @param {string | PersistedWindowLayout} name - Name of the window layout to load or the layout itself
+     * @returns {Promise<PersistedWindowLayout>} - A promise that returns {@link PersistedWindowLayout} that is loaded
      */
-    loadLayout(name: string): Promise<PersistedWindowLayout>;
+    loadLayout(layout: string | PersistedWindowLayout): Promise<PersistedWindowLayout>;
 
     /**
      * Builds the current window layout


### PR DESCRIPTION
Change loadLayout param to union type of string | PersistedWindowLayout.  This will maintain backcompat to retrieve from storage provider by name but flexibility of providing an a layout itself to apply.

Fixes #269