### PR TITLE
Update getMainWindow to return 'root' window

### DIFF
--- a/packages/desktopjs/src/Default/default.ts
+++ b/packages/desktopjs/src/Default/default.ts
@@ -218,11 +218,12 @@ export namespace Default {
      */
     export class DefaultContainer extends WebContainerBase {
         private mainWindow: ContainerWindow;
-        private windows: ContainerWindow[];
 
         public static readonly windowsPropertyKey: string = "desktopJS-windows";
         public static readonly windowUuidPropertyKey: string = "desktopJS-uuid";
         public static readonly windowNamePropertyKey: string = "desktopJS-name";
+
+        private static readonly rootWindowUuid: string = "root";
 
         public static readonly defaultWindowOptionsMap: PropertyMap = {
             x: { target: "left" },
@@ -240,6 +241,7 @@ export namespace Default {
             // Create a global windows object for tracking all windows and add the current global window for current
             if (this.globalWindow && !(DefaultContainer.windowsPropertyKey in this.globalWindow)) {
                 this.globalWindow[DefaultContainer.windowsPropertyKey] = { root: this.globalWindow };
+                this.globalWindow[DefaultContainer.windowNamePropertyKey] = this.globalWindow[DefaultContainer.windowUuidPropertyKey] = DefaultContainer.rootWindowUuid;
             }
 
             this.screen = new DefaultDisplayManager(this.globalWindow);
@@ -251,7 +253,8 @@ export namespace Default {
 
         public getMainWindow(): ContainerWindow {
             if (!this.mainWindow) {
-                this.mainWindow = new DefaultContainerWindow(this.globalWindow);
+                const win = this.globalWindow[DefaultContainer.windowsPropertyKey].root;
+                this.mainWindow = win ? this.wrapWindow(win) : null;
             }
 
             return this.mainWindow;

--- a/packages/desktopjs/tests/unit/Default/default.spec.ts
+++ b/packages/desktopjs/tests/unit/Default/default.spec.ts
@@ -336,6 +336,7 @@ describe("DefaultContainer", () => {
         let container: Default.DefaultContainer = new Default.DefaultContainer(window);
         let win: ContainerWindow = container.getMainWindow();
         expect(win).toBeDefined();
+        expect(win.id).toEqual("root");
         expect(win.innerWindow).toEqual(window);
     });
 


### PR DESCRIPTION
- getMainWindow will return the 'root' window which is the first window that invoked resolveContainer
- Set name and id of root window to "root" for better support of comparing windows by id/name and getWindow*

Fixes #42 